### PR TITLE
Vendor joyomni_ops CUDA kernels; drop sgl-kernel dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ __pycache__/
 *.egg-info/
 .ipynb_checkpoints/
 
+# joyomni_ops native build artifacts (built from source; never commit binaries)
+joyomni_ops/build/
+*.so
+
 # OS / editor
 .DS_Store
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -40,6 +40,21 @@ python -m pip install --upgrade pip setuptools wheel
 python -m pip install -r requirements.txt
 ```
 
+The fused DiT CUDA kernels (RMSNorm, adaLN modulate, 3D-RoPE QK-norm, and the
+FP8 quant/GEMM) are provided by the vendored `joyomni_ops` package, not by
+sgl-kernel. Build and install it from the repo root:
+
+```bash
+# Full build (FP8 GEMM included): point at a cutlass checkout, tag
+# 57e3cfb47a2d9e0d46eb6335c3dc411498efa198, CUDA >= 12.8 for Blackwell SASS.
+JOYOMNI_OPS_CUTLASS_DIR=/path/to/cutlass python -m pip install ./joyomni_ops
+
+# Light build (no FP8 GEMM, no cutlass needed) — set JOYOMNI_FP8_IMG=0 at runtime:
+# JOYOMNI_OPS_NO_FP8=1 python -m pip install ./joyomni_ops
+```
+
+See `joyomni_ops/README.md` for op list, GPU-arch selection, and benchmarks.
+
 Verify the key runtime imports:
 
 ```bash
@@ -48,10 +63,11 @@ import torch
 import cv2
 import av
 import flash_attn.cute
-import sgl_kernel
+import joyomni_ops
 
 print("torch", torch.__version__, "cuda", torch.version.cuda)
 print("cuda available:", torch.cuda.is_available())
+print("joyomni_ops fp8:", joyomni_ops.has_fp8())
 print("cv2", cv2.__version__)
 PY
 ```
@@ -98,7 +114,7 @@ The public deployment package was tested with a single NVIDIA B200 GPU:
 | Transformers / Diffusers | `4.57.0` / `0.36.0` |
 | FastAPI / Uvicorn | `0.117.1` / `0.37.0` |
 | OpenCV / PyAV | `opencv-python-headless 4.13.0.92` / `av 13.1.0` |
-| Attention / kernel packages | `flash-attn-4 4.0.0b13`, `sgl-kernel 0.3.18.post2`, `triton 3.5.1`, `nvidia-cutlass-dsl 4.5.1` |
+| Attention / kernel packages | `flash-attn-4 4.0.0b13`, `joyomni_ops 0.1.0` (vendored, built from source), `triton 3.5.1`, `nvidia-cutlass-dsl 4.5.1` |
 
 ## 2. Clone JoyAI-Video-Edit Weights
 

--- a/deploy/xvideo/models/dit/fp8_linear.py
+++ b/deploy/xvideo/models/dit/fp8_linear.py
@@ -6,8 +6,8 @@ import torch
 import torch.nn as nn
 
 try:
-    from sgl_kernel import fp8_scaled_mm, sgl_per_token_quant_fp8
-    _SGL_KERNEL_OK = True
+    from joyomni_ops import fp8_scaled_mm, has_fp8, sgl_per_token_quant_fp8
+    _SGL_KERNEL_OK = bool(has_fp8())
 except Exception:
     fp8_scaled_mm = None
     sgl_per_token_quant_fp8 = None
@@ -51,7 +51,7 @@ class Fp8Linear(nn.Module):
 
     @classmethod
     def from_linear(cls, lin: nn.Linear, out_dtype: torch.dtype = torch.bfloat16) -> "Fp8Linear":
-        assert available(), "sgl_kernel not importable; cannot build Fp8Linear"
+        assert available(), "joyomni_ops fp8 ops not available; cannot build Fp8Linear"
         w = lin.weight.data
         w_q, w_s = _quantize_weight_per_channel(w.to(torch.bfloat16))
         b = None

--- a/deploy/xvideo/models/dit/sgl_fused_ops.py
+++ b/deploy/xvideo/models/dit/sgl_fused_ops.py
@@ -19,7 +19,11 @@ def _try_import() -> bool:
     global _AVAILABLE, _FUSED_NORM_SCALE_SHIFT, _FUSED_QK_NORM_ROPE_3D, _RMSNORM
     if _AVAILABLE is not None:
         return _AVAILABLE
-    from sgl_kernel import fused_norm_scale_shift, fused_qk_norm_rope_3d_paired, rmsnorm
+    try:
+        from joyomni_ops import fused_norm_scale_shift, fused_qk_norm_rope_3d_paired, rmsnorm
+    except Exception:
+        _AVAILABLE = False
+        return _AVAILABLE
     _RMSNORM = rmsnorm
     _FUSED_NORM_SCALE_SHIFT = fused_norm_scale_shift
     _FUSED_QK_NORM_ROPE_3D = fused_qk_norm_rope_3d_paired
@@ -37,7 +41,9 @@ def fused_layernorm_modulate(
     eps: float = 1e-6,
 ) -> torch.Tensor:
     if not _try_import():
-        raise RuntimeError("sgl_kernel not available")
+        raise RuntimeError(
+            "joyomni_ops not available; build it with `pip install ./joyomni_ops`"
+        )
     B, L, D = x.shape
     x_2d = x.reshape(-1, D)
 
@@ -64,7 +70,9 @@ def fused_qk_norm_rope_3d(
     eps: float = 1e-6,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     if not _try_import():
-        raise RuntimeError("sgl_kernel not available")
+        raise RuntimeError(
+            "joyomni_ops not available; build it with `pip install ./joyomni_ops`"
+        )
     if q.dtype != torch.bfloat16:
         raise RuntimeError(
             f"fused_qk_norm_rope_3d requires bf16 q/k, got {q.dtype}"
@@ -101,7 +109,9 @@ def fused_qk_norm_rope_3d(
 
 def rmsnorm_qk_bf16(x: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
     if not _try_import() or _RMSNORM is None:
-        raise RuntimeError("sgl_kernel rmsnorm not available")
+        raise RuntimeError(
+            "joyomni_ops rmsnorm not available; build it with `pip install ./joyomni_ops`"
+        )
     assert x.dtype == torch.bfloat16, f"rmsnorm_qk_bf16 needs bf16, got {x.dtype}"
     orig_shape = x.shape
     D = orig_shape[-1]

--- a/joyomni_ops/README.md
+++ b/joyomni_ops/README.md
@@ -1,0 +1,90 @@
+# joyomni_ops
+
+Minimal, self-contained CUDA operator library for the JoyOmni V2V DiT pipeline,
+extracted from [sgl-kernel](https://github.com/sgl-project/sglang/tree/main/sgl-kernel).
+
+**No `sglang` / `sgl_kernel` / `flashinfer` runtime dependency.** Only the ops the
+pipeline actually uses, in one small `.so` (~1 MB without the FP8 GEMM, tens of MB
+with it — versus sgl-kernel's ~350 MB `common_ops.so`).
+
+## Ops
+
+| op | description | deps |
+|---|---|---|
+| `fused_qk_norm_rope_3d_paired` | fused RMSNorm(q,k) + interleaved 3D RoPE (bf16, in-place) | none |
+| `fused_norm_scale_shift` | `Norm(x; γ, β) * (1 + scale) + shift` (Layer/RMS, adaLN) | none |
+| `rmsnorm` | `(x / RMS(x)) * weight` | none (self-written) |
+| `sgl_per_token_quant_fp8` | dynamic per-token bf16/fp16 → fp8_e4m3 quant | none (self-written) |
+| `fp8_scaled_mm` | FP8 per-token × per-channel scaled GEMM | cutlass |
+
+The first three and the quant are dependency-free hand-written CUDA. Only
+`fp8_scaled_mm` needs cutlass (ported from the sgl-kernel/TensorRT-LLM template).
+
+## Build
+
+```bash
+# Full build (needs a cutlass checkout; CUDA >= 12.8 for Blackwell SASS):
+JOYOMNI_OPS_CUTLASS_DIR=/path/to/cutlass pip install .
+
+# Light build, no FP8 GEMM / no cutlass:
+JOYOMNI_OPS_NO_FP8=1 pip install .
+```
+
+### GPU architectures
+
+Chosen automatically from the local nvcc:
+- always: `sm_80`, `sm_89`, `sm_90`
+- CUDA ≥ 12.8: also `sm_100a` (B200) and `sm_120a` (RTX 5090)
+- on CUDA < 12.8 an `sm_90` PTX is embedded so the driver JITs for Blackwell
+  (correctness only; build on CUDA ≥ 12.8 for tuned Blackwell SASS)
+
+Override with `JOYOMNI_OPS_CUDA_ARCHS="90;100a;120a"`.
+
+cutlass tag matching the reference build: `57e3cfb47a2d9e0d46eb6335c3dc411498efa198`.
+
+## Usage
+
+```python
+import joyomni_ops as jo
+jo.rmsnorm(x, weight, eps)
+jo.fused_norm_scale_shift(x, gamma, beta, scale, shift, "layer", eps)
+jo.fused_qk_norm_rope_3d_paired(q, k, seq_len, num_heads, eps, qw, kw, cos, sin)  # in-place
+jo.sgl_per_token_quant_fp8(x_2d, out_q, out_s)
+y = jo.fp8_scaled_mm(x_q, w_fp8, x_scale, w_scale, out_dtype, bias)
+```
+
+## Tests
+
+```bash
+python tests/test_parity_light.py          # parity vs sgl_kernel (quick)
+python tests/test_bench.py --dtype bf16    # speed + accuracy vs pure-torch (also --dtype fp16)
+```
+
+## Benchmarks
+
+Measured on NVIDIA B20Z (sm_100), bf16, 4096×4096 shapes, CUDA-event timed.
+"vs torch" = accuracy against a pure-PyTorch (fp32-accumulate) reference;
+"vs sgl" = against the original sgl_kernel op; speedup vs the equivalent eager
+PyTorch ops.
+
+| op | accuracy vs torch (rel) | accuracy vs sgl (max_abs) | speedup vs torch |
+|---|---|---|---|
+| `rmsnorm` | 1e-8 (equivalent) | 1.5e-2 (bf16 rounding) | **5.7×** |
+| `fused_norm_scale_shift` | 3e-8 (equivalent) | **0** | **11.6×** |
+| `fused_qk_norm_rope_3d_paired` | 6e-8 (equivalent) | **0** | **10.6×** |
+| `fp8_scaled_mm` (mm only) | 3.7% (fp8 quant) | **0** | **1.6×** |
+| fp8 linear (dyn-quant + mm) | 3.7% | **0** | ~0.95× |
+
+Notes:
+- The 3 fused kernels are numerically **equivalent** to eager PyTorch (rel ~1e-8);
+  the speedup comes from fusing several ops into one kernel launch.
+- fp8's ~3.7% error is the **inherent fp8 quantization loss**, not a bug. The mm
+  itself is 1.6× faster; the "quant + mm" row includes per-call activation
+  quantization — in production the weight is pre-quantized and activation quant
+  can be fused upstream, so the mm-only figure is the relevant one.
+- fp16 results are within noise of bf16 (fp8 mm ~1.6×, fused ops 5.7–11.8×).
+
+## License
+
+Apache-2.0. Portions derive from sgl-kernel (SGLang Team) and NVIDIA
+TensorRT-LLM / cutlass; original copyright headers retained in the sources.

--- a/joyomni_ops/csrc/fp8_gemm.cu
+++ b/joyomni_ops/csrc/fp8_gemm.cu
@@ -1,0 +1,1548 @@
+/* Copyright 2025 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Adapted from
+// https://github.com/NVIDIA/TensorRT-LLM/blob/v0.16.0/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_template.h
+// https://github.com/NVIDIA/TensorRT-LLM/blob/v0.16.0/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_kernel_template_sm89.h
+// https://github.com/NVIDIA/TensorRT-LLM/blob/v0.16.0/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_kernel_template_sm90.h
+
+#include <ATen/cuda/CUDAContext.h>
+#include <cudaTypedefs.h>
+#include <cutlass/arch/arch.h>
+#include <cutlass/arch/memory.h>
+#include <cutlass/arch/mma.h>
+#include <cutlass/array.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/epilogue/thread/activation.h>
+#include <cutlass/epilogue/thread/linear_combination.h>
+#include <cutlass/epilogue/threadblock/default_thread_map_tensor_op.h>
+#include <cutlass/gemm/device/gemm.h>
+#include <cutlass/gemm/device/gemm_universal_adapter.h>
+#include <cutlass/gemm/gemm.h>
+#include <cutlass/gemm/kernel/default_gemm_universal_with_visitor.h>
+#include <cutlass/gemm/thread/mma.h>
+#include <cutlass/layout/matrix.h>
+#include <cutlass/matrix_coord.h>
+#include <cutlass/numeric_types.h>
+#include <cutlass/tensor_ref.h>
+#include <torch/all.h>
+
+#include <cute/tensor.hpp>
+#include <cutlass/epilogue/collective/collective_builder.hpp>
+#include <cutlass/epilogue/collective/default_epilogue.hpp>
+#include <cutlass/epilogue/threadblock/fusion/visitors.hpp>
+#include <cutlass/gemm/collective/collective_builder.hpp>
+#include <cutlass/gemm/dispatch_policy.hpp>
+#include <cutlass/gemm/kernel/gemm_universal.hpp>
+#include <cutlass/util/packed_stride.hpp>
+
+#include "math.hpp"
+#include "joyomni_ops.h"
+
+using namespace cute;
+
+#if defined CUDA_VERSION && CUDA_VERSION >= 12040
+template <
+    typename ElementType,
+    typename OutElementType,
+    typename AccumElementType,
+    typename CtaShape,
+    typename WarpShape,
+    int Stages,
+    bool WithBias,
+    typename FP8MathOperator = cutlass::arch::OpMultiplyAdd,
+    template <typename...> typename EpilogueVisitor = cutlass::epilogue::threadblock::Sm80EVT,
+    typename ThreadblockSwizzle = cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>>
+struct DeviceGemmFp8RowwiseSm89 {
+  static_assert(std::is_same_v<ElementType, cutlass::float_e4m3_t>, "ElementType must be FP8(e4m3)");
+
+  using ElementA = ElementType;
+  using LayoutA = cutlass::layout::RowMajor;
+  static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+
+  using ElementB = ElementType;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+
+  using ElementC = OutElementType;
+  using LayoutC = cutlass::layout::RowMajor;
+  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+
+  using ElementOutput = OutElementType;
+  using LayoutOutput = cutlass::layout::RowMajor;
+  static constexpr int AlignmentOutput = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+  using ElementAccumulator = AccumElementType;
+  using ElementComputeEpilogue = float;
+  using ArchTag = cutlass::arch::Sm89;
+  using OperatorClass = cutlass::arch::OpClassTensorOp;
+
+  using InstructionShape = cutlass::gemm::GemmShape<16, 8, 32>;
+  // Number of epilogue stages in EVT
+  static constexpr int EVTEpilogueStages = 1;
+
+  using OutputTileThreadMap = cutlass::epilogue::threadblock::
+      OutputTileThreadLayout<CtaShape, WarpShape, ElementC, AlignmentC, EVTEpilogueStages>;
+
+  // Definition of EVT
+  using accSrc = cutlass::epilogue::threadblock::VisitorAccFetch;
+
+  using ComputeBScale = cutlass::epilogue::threadblock::VisitorCompute<
+      cutlass::multiplies,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+  using bScaleSrc = cutlass::epilogue::threadblock::
+      VisitorRowBroadcast<OutputTileThreadMap, ElementComputeEpilogue, Stride<_0, _1, _0>>;
+  using EpilogueBScale = cutlass::epilogue::threadblock::Sm80EVT<ComputeBScale, accSrc, bScaleSrc>;
+
+  using ComputeAScale = cutlass::epilogue::threadblock::
+      VisitorCompute<cutlass::multiplies, ElementC, ElementComputeEpilogue, cutlass::FloatRoundStyle::round_to_nearest>;
+  using aScaleSrc = cutlass::epilogue::threadblock::
+      VisitorColBroadcast<OutputTileThreadMap, ElementComputeEpilogue, Stride<_1, _0, _0>>;
+  using EpilogueAScale = cutlass::epilogue::threadblock::Sm80EVT<ComputeAScale, EpilogueBScale, aScaleSrc>;
+
+  // With bias
+  using biasSrc =
+      cutlass::epilogue::threadblock::VisitorRowBroadcast<OutputTileThreadMap, ElementOutput, Stride<_0, _1, _0>>;
+  using ComputeAScaleWithBias = cutlass::epilogue::threadblock::VisitorCompute<
+      cutlass::multiply_add,
+      ElementC,
+      ElementComputeEpilogue,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+  using EpilogueAScaleWithBias =
+      cutlass::epilogue::threadblock::Sm80EVT<ComputeAScaleWithBias, EpilogueBScale, aScaleSrc, biasSrc>;
+
+  using dTar = cutlass::epilogue::threadblock::VisitorAuxStore<
+      OutputTileThreadMap,
+      ElementC,
+      cutlass::FloatRoundStyle::round_to_nearest,
+      Stride<int64_t, _1, _0>>;
+  using EpilogueStore = typename cutlass::platform::conditional<
+      WithBias,
+      cutlass::epilogue::threadblock::Sm80EVT<dTar, EpilogueAScaleWithBias>,
+      cutlass::epilogue::threadblock::Sm80EVT<dTar, EpilogueAScale>>::type;
+
+  using EpilogueOp = EpilogueStore;
+
+  using GemmKernel = typename cutlass::gemm::kernel::DefaultGemmWithVisitor<
+      ElementA,
+      LayoutA,
+      cutlass::ComplexTransform::kNone,
+      AlignmentA,
+      ElementB,
+      LayoutB,
+      cutlass::ComplexTransform::kNone,
+      AlignmentB,
+      ElementC,
+      LayoutC,
+      AlignmentC,
+      ElementAccumulator,
+      ElementComputeEpilogue,
+      OperatorClass,
+      ArchTag,
+      CtaShape,
+      WarpShape,
+      InstructionShape,
+      EpilogueOp,
+      ThreadblockSwizzle,
+      Stages,
+      FP8MathOperator,
+      EVTEpilogueStages>::GemmKernel;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+template <typename Gemm, bool WithBias>
+typename Gemm::Arguments prepare_sm89_fp8_args(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  using ElementT = typename Gemm::ElementA;
+  using ElementOutput = typename Gemm::ElementD;
+  using ElementComputeEpilogue = float;
+
+  int32_t m = a.size(0);
+  int32_t n = b.size(1);
+  int32_t k = a.size(1);
+
+  int64_t lda = a.stride(0);
+  int64_t ldb = b.stride(1);
+  int64_t ldc = out.stride(0);
+
+  ElementT const* ptr_a = reinterpret_cast<ElementT const*>(a.data_ptr());
+  ElementT const* ptr_b = reinterpret_cast<ElementT const*>(b.data_ptr());
+  ElementOutput const* ptr_bias = nullptr;
+  if constexpr (WithBias) {
+    TORCH_CHECK(bias.has_value())
+    ptr_bias = reinterpret_cast<ElementOutput const*>(bias.value().data_ptr());
+  }
+  ElementOutput* ptr_d = reinterpret_cast<ElementOutput*>(out.data_ptr());
+  ElementComputeEpilogue const* ptr_scales_a = reinterpret_cast<ElementComputeEpilogue const*>(scales_a.data_ptr());
+  ElementComputeEpilogue const* ptr_scales_b = reinterpret_cast<ElementComputeEpilogue const*>(scales_b.data_ptr());
+
+  typename Gemm::Arguments args(
+      cutlass::gemm::GemmUniversalMode::kGemm,  // Mode
+      {m, n, k},                                // Problem size
+      1,                                        // Split-k factor
+      {},                                       // Epilogue args
+      ptr_a,                                    // a pointer
+      ptr_b,                                    // b pointer
+      nullptr,                                  // c pointer (unused)
+      nullptr,                                  // d pointer (unused)
+      m * k,                                    // batch stride a (unused)
+      n * k,                                    // batch stride b (unused)
+      m * n,                                    // batch stride c (unused)
+      m * n,                                    // batch stride d (unused)
+      lda,                                      // stride a
+      ldb,                                      // stride b
+      ldc,                                      // stride c (unused)
+      ldc);                                     // stride d (unused)
+  if constexpr (WithBias) {
+    args.epilogue = {
+        {
+            {
+                {},  // Accumulator
+                {ptr_scales_b, ElementComputeEpilogue(0), {_0{}, _1{}, _0{}}},
+                {}  // Multiplies
+            },
+            {ptr_scales_a, ElementComputeEpilogue(0), {_1{}, _0{}, _0{}}},
+            {ptr_bias, ElementOutput(0), {_0{}, _1{}, _0{}}},
+            {}  // Multiplies
+        },
+        {ptr_d, {n, _1{}, _0{}}}};
+  } else {
+    args.epilogue = {
+        {
+            {
+                {},  // Accumulator
+                {ptr_scales_b, ElementComputeEpilogue(0), {_0{}, _1{}, _0{}}},
+                {}  // Multiplies
+            },
+            {ptr_scales_a, ElementComputeEpilogue(0), {_1{}, _0{}, _0{}}},
+            {}  // Multiplies
+        },
+        {ptr_d, {n, _1{}, _0{}}}};
+  }
+
+  return args;
+}
+
+template <typename Gemm, bool WithBias>
+void launch_sm89_fp8_scaled_mm(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  auto args = prepare_sm89_fp8_args<Gemm, WithBias>(out, a, b, scales_a, scales_b, bias);
+  Gemm gemm_op;
+
+  size_t workspace_size = gemm_op.get_workspace_size(args);
+  auto const workspace_options = torch::TensorOptions().dtype(torch::kUInt8).device(a.device());
+  auto workspace = torch::empty(workspace_size, workspace_options);
+  auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
+
+  auto can_implement = gemm_op.can_implement(args);
+  TORCH_CHECK(can_implement == cutlass::Status::kSuccess)
+
+  auto status = gemm_op(args, workspace.data_ptr(), stream);
+  TORCH_CHECK(status == cutlass::Status::kSuccess)
+}
+
+template <typename OutType, typename CtaShape, typename WarpShape, int Stages>
+void sm89_fp8_dispatch_bias(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  using ElementInput = cutlass::float_e4m3_t;
+  using ElementOutput = OutType;
+  using AccumElementType = float;
+  if (bias) {
+    using Gemm = typename DeviceGemmFp8RowwiseSm89<
+        ElementInput,
+        ElementOutput,
+        AccumElementType,
+        CtaShape,
+        WarpShape,
+        Stages,
+        true>::Gemm;
+    return launch_sm89_fp8_scaled_mm<Gemm, true>(out, a, b, scales_a, scales_b, bias);
+  } else {
+    using Gemm = typename DeviceGemmFp8RowwiseSm89<
+        ElementInput,
+        ElementOutput,
+        AccumElementType,
+        CtaShape,
+        WarpShape,
+        Stages,
+        false>::Gemm;
+    return launch_sm89_fp8_scaled_mm<Gemm, false>(out, a, b, scales_a, scales_b, bias);
+  }
+}
+
+template <typename OutType>
+void sm89_fp8_dispatch_shape(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  uint32_t const m = a.size(0);
+  uint32_t const n = out.size(1);
+
+  if (m == 1) {
+    if (n <= 8192) {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<16, 64, 128>,
+          cutlass::gemm::GemmShape<16, 64, 64>,
+          7>(out, a, b, scales_a, scales_b, bias);
+    } else {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<32, 64, 128>,
+          cutlass::gemm::GemmShape<16, 64, 64>,
+          5>(out, a, b, scales_a, scales_b, bias);
+    }
+  } else if (m <= 16) {
+    // M in (1, 16]
+    if (n <= 8192) {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<16, 64, 128>,
+          cutlass::gemm::GemmShape<16, 64, 64>,
+          4>(out, a, b, scales_a, scales_b, bias);
+    } else if (n <= 16384) {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<32, 64, 128>,
+          cutlass::gemm::GemmShape<16, 64, 64>,
+          5>(out, a, b, scales_a, scales_b, bias);
+    } else {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<16, 64, 128>,
+          cutlass::gemm::GemmShape<16, 64, 64>,
+          7>(out, a, b, scales_a, scales_b, bias);
+    }
+  } else if (m <= 64) {
+    // M in (16, 64]
+    if (n <= 16384) {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<32, 64, 128>,
+          cutlass::gemm::GemmShape<16, 64, 64>,
+          7>(out, a, b, scales_a, scales_b, bias);
+    } else {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<16, 64, 128>,
+          cutlass::gemm::GemmShape<16, 64, 64>,
+          7>(out, a, b, scales_a, scales_b, bias);
+    }
+  } else if (m <= 128) {
+    // M in (64, 128]
+    if (n <= 8192) {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<64, 64, 128>,
+          cutlass::gemm::GemmShape<32, 64, 64>,
+          4>(out, a, b, scales_a, scales_b, bias);
+    } else if (n <= 16384) {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<64, 64, 128>,
+          cutlass::gemm::GemmShape<32, 64, 64>,
+          5>(out, a, b, scales_a, scales_b, bias);
+    } else {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<32, 64, 128>,
+          cutlass::gemm::GemmShape<16, 64, 64>,
+          5>(out, a, b, scales_a, scales_b, bias);
+    }
+  } else if (m <= 256) {
+    // M in (128, 256]
+    if (n <= 8192) {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<128, 64, 64>,
+          cutlass::gemm::GemmShape<64, 32, 64>,
+          5>(out, a, b, scales_a, scales_b, bias);
+    } else if (n <= 16384) {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<64, 128, 64>,
+          cutlass::gemm::GemmShape<64, 32, 64>,
+          7>(out, a, b, scales_a, scales_b, bias);
+    } else {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<128, 64, 128>,
+          cutlass::gemm::GemmShape<64, 32, 128>,
+          4>(out, a, b, scales_a, scales_b, bias);
+    }
+  } else if (m <= 512) {
+    // M in (256, 512)
+    if (n <= 16384) {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<128, 128, 64>,
+          cutlass::gemm::GemmShape<64, 32, 64>,
+          2>(out, a, b, scales_a, scales_b, bias);
+    } else {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<128, 128, 64>,
+          cutlass::gemm::GemmShape<64, 32, 64>,
+          4>(out, a, b, scales_a, scales_b, bias);
+    }
+  } else {
+    // M in (512, inf)
+    if (n <= 8192) {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<128, 128, 64>,
+          cutlass::gemm::GemmShape<64, 32, 64>,
+          3>(out, a, b, scales_a, scales_b, bias);
+    } else {
+      return sm89_fp8_dispatch_bias<
+          OutType,
+          cutlass::gemm::GemmShape<128, 128, 64>,
+          cutlass::gemm::GemmShape<64, 32, 64>,
+          2>(out, a, b, scales_a, scales_b, bias);
+    }
+  }
+}
+#endif
+
+#if defined CUDA_VERSION && CUDA_VERSION >= 12000
+template <
+    typename ElementType,
+    typename OutElementType,
+    typename AccumElementType,
+    typename CTAShape,
+    typename ClusterShape,
+    typename MainloopScheduleType,
+    typename EpilogueScheduleType,
+    typename TileSchedulerType = void,
+    bool WithBias = false>
+struct DeviceGemmFp8RowwiseSm90 {
+  static_assert(std::is_same_v<ElementType, cutlass::float_e4m3_t>, "ElementType must be FP8(e4m3)");
+
+  // A matrix configuration
+  using ElementA = ElementType;               // Element type for A matrix operand
+  using LayoutA = cutlass::layout::RowMajor;  // Layout type for A matrix operand
+  static constexpr int AlignmentA =
+      128 / cutlass::sizeof_bits<ElementA>::value;  // Memory access granularity/alignment of A
+                                                    // matrix in units of elements (up to 16 bytes)
+
+  // B matrix configuration
+  using ElementB = ElementType;                  // Element type for B matrix operand
+  using LayoutB = cutlass::layout::ColumnMajor;  // Layout type for B matrix operand
+  static constexpr int AlignmentB =
+      128 / cutlass::sizeof_bits<ElementB>::value;  // Memory access granularity/alignment of B
+                                                    // matrix in units of elements (up to 16 bytes)
+
+  // C/D matrix configuration
+  using ElementC = void;                      // Element type for C matrix operands
+  using LayoutC = cutlass::layout::RowMajor;  // Layout type for C matrix operands
+  static constexpr int AlignmentC =
+      128 / cutlass::sizeof_bits<OutElementType>::value;  // Memory access granularity/alignment of C matrices in
+                                                          // units of elements (up to 16 bytes)
+
+  // Output matrix configuration
+  using ElementOutput = OutElementType;            // Element type for output matrix operands
+  using LayoutOutput = cutlass::layout::RowMajor;  // Layout type for output matrix operands
+  static constexpr int AlignmentOutput = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+  // // Auxiliary matrix configuration and other fusion types
+  // using ElementBias = float;
+
+  // Multiply-accumulate blocking/pipelining details
+  using ElementAccumulator = AccumElementType;  // Element type for internal accumulation
+  using ElementCompute = float;                 // Element type for compute
+  using ElementComputeEpilogue = float;
+  using ArchTag = cutlass::arch::Sm90;  // Tag indicating the minimum SM that supports the intended feature
+  using OperatorClass = cutlass::arch::OpClassTensorOp;  // Operator class tag
+  using TileShape = CTAShape;                            // Threadblock-level tile size
+
+  static constexpr bool PONG = false;
+  static constexpr bool FAST_ACCUM = true;
+  static constexpr bool USE_BIAS = false;
+
+  using StageCountType = cutlass::gemm::collective::StageCountAuto;      // Stage count maximized
+                                                                         // based on the tile size
+  using KernelSchedule = cutlass::gemm::collective::KernelScheduleAuto;  // Kernel to launch based on the default
+                                                                         // setting in the Collective Builder
+  // Implement rowwise scaling epilogue.
+  using XScale = cutlass::epilogue::fusion::Sm90ColBroadcast<
+      0,
+      TileShape,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cute::Stride<cute::Int<1>, cute::Int<0>, cute::Int<0>>>;
+
+  using WScale = cutlass::epilogue::fusion::Sm90RowBroadcast<
+      0,
+      TileShape,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
+
+  using Bias = cutlass::epilogue::fusion::Sm90RowBroadcast<
+      0,
+      TileShape,
+      ElementOutput,
+      ElementOutput,
+      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
+
+  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+
+  using Compute0 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies,
+      ElementComputeEpilogue,  // First stage output type.
+      ElementComputeEpilogue,  // First stage input types.
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute0 = cutlass::epilogue::fusion::Sm90EVT<Compute0, WScale, Accum>;
+
+  using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies,
+      ElementOutput,
+      ElementComputeEpilogue,  // Second stage input types.
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute1 = cutlass::epilogue::fusion::Sm90EVT<Compute1, XScale, EVTCompute0>;
+
+  // With bias
+  using ComputeWithBias = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiply_add,
+      ElementOutput,
+      ElementComputeEpilogue,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+  using EVTComputeWithBias = cutlass::epilogue::fusion::Sm90EVT<ComputeWithBias, XScale, EVTCompute0, Bias>;
+
+  using EpilogueEVT = typename cutlass::platform::conditional<WithBias, EVTComputeWithBias, EVTCompute1>::type;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm90,
+      cutlass::arch::OpClassTensorOp,
+      TileShape,
+      ClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulator,
+      ElementComputeEpilogue,
+      ElementC,
+      LayoutC,
+      AlignmentC,
+      ElementOutput,
+      LayoutOutput,
+      AlignmentOutput,
+      cutlass::epilogue::TmaWarpSpecialized,
+      EpilogueEVT>::CollectiveOp;
+
+  using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecialized;
+  using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
+  using FastDefaultSchedule = cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum;
+  using FastPongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
+
+  using SlowAccum = DefaultSchedule;
+  using FastAccum = FastPongSchedule;  // Default apply Pingpong
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      ArchTag,
+      OperatorClass,
+      ElementA,
+      LayoutA,
+      AlignmentA,
+      ElementB,
+      LayoutB,
+      AlignmentB,
+      ElementAccumulator,
+      TileShape,
+      ClusterShape,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+          sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      MainloopScheduleType>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>,  // Indicates ProblemShape
+      CollectiveMainloop,
+      CollectiveEpilogue,
+      TileSchedulerType>;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+template <typename Gemm, bool WithBias>
+typename Gemm::Arguments prepare_sm90_fp8_args(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  using ElementT = typename Gemm::ElementA;
+  using ElementOutput = typename Gemm::ElementD;
+  using ElementComputeEpilogue = float;
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using StrideC = typename Gemm::GemmKernel::StrideC;
+  using StrideD = typename Gemm::GemmKernel::StrideD;
+
+  int32_t m = a.size(0);
+  int32_t n = b.size(1);
+  int32_t k = a.size(1);
+  ElementT const* ptr_a = reinterpret_cast<ElementT const*>(a.data_ptr());
+  ElementT const* ptr_b = reinterpret_cast<ElementT const*>(b.data_ptr());
+  ElementOutput const* ptr_bias = nullptr;
+  if constexpr (WithBias) {
+    TORCH_CHECK(bias.has_value())
+    ptr_bias = reinterpret_cast<ElementOutput const*>(bias.value().data_ptr());
+  }
+  ElementOutput* ptr_d = reinterpret_cast<ElementOutput*>(out.data_ptr());
+  ElementComputeEpilogue const* ptr_scales_a = reinterpret_cast<ElementComputeEpilogue const*>(scales_a.data_ptr());
+  ElementComputeEpilogue const* ptr_scales_b = reinterpret_cast<ElementComputeEpilogue const*>(scales_b.data_ptr());
+
+  StrideA stride_a = cutlass::make_cute_packed_stride(StrideA{}, make_shape(m, k, 1));
+  StrideB stride_b = cutlass::make_cute_packed_stride(StrideB{}, make_shape(n, k, 1));
+  StrideC stride_c;
+  StrideD stride_d = cutlass::make_cute_packed_stride(StrideD{}, make_shape(m, n, 1));
+  typename Gemm::Arguments args = {
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {m, n, k, 1},
+      {ptr_a, stride_a, ptr_b, stride_b},
+      {{},  // epilogue.thread
+       nullptr,
+       stride_c,
+       ptr_d,
+       stride_d}};
+  if constexpr (WithBias) {
+    args.epilogue.thread = {
+        {ptr_scales_a},
+        {
+            {ptr_scales_b},
+            {},  // Accumulator
+            {}   // Multiplies
+        },
+        {ptr_bias},
+        {},  // Multiplies
+    };
+  } else {
+    args.epilogue.thread = {
+        {ptr_scales_a},
+        {
+            {ptr_scales_b},
+            {},  // Accumulator
+            {}   // Multiplies
+        },
+        {},  // Multiplies
+    };
+  }
+
+  return args;
+}
+
+template <typename Gemm, bool WithBias>
+void launch_sm90_fp8_scaled_mm(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  auto args = prepare_sm90_fp8_args<Gemm, WithBias>(out, a, b, scales_a, scales_b, bias);
+  Gemm gemm_op;
+
+  size_t workspace_size = gemm_op.get_workspace_size(args);
+  auto const workspace_options = torch::TensorOptions().dtype(torch::kUInt8).device(a.device());
+  auto workspace = torch::empty(workspace_size, workspace_options);
+  auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
+
+  auto can_implement = gemm_op.can_implement(args);
+  TORCH_CHECK(can_implement == cutlass::Status::kSuccess)
+
+  auto status = gemm_op.run(args, workspace.data_ptr(), stream);
+
+  TORCH_CHECK(status == cutlass::Status::kSuccess)
+}
+
+template <
+    typename OutType,
+    typename CTAShape,
+    typename ClusterShape,
+    typename MainloopScheduleType,
+    typename TileSchedulerType>
+void sm90_fp8_dispatch_bias(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias,
+    bool fast_accum = true,
+    bool use_persistent = false) {
+  using ElementInput = cutlass::float_e4m3_t;
+  using ElementOutput = OutType;
+  using AccumElementType = float;
+  using EpilogueScheduleType = cutlass::epilogue::TmaWarpSpecialized;
+
+  if (bias) {
+    using Gemm = typename DeviceGemmFp8RowwiseSm90<
+        ElementInput,
+        ElementOutput,
+        AccumElementType,
+        CTAShape,
+        ClusterShape,
+        MainloopScheduleType,
+        EpilogueScheduleType,
+        TileSchedulerType,
+        true>::Gemm;
+    return launch_sm90_fp8_scaled_mm<Gemm, true>(out, a, b, scales_a, scales_b, bias);
+  } else {
+    using Gemm = typename DeviceGemmFp8RowwiseSm90<
+        ElementInput,
+        ElementOutput,
+        AccumElementType,
+        CTAShape,
+        ClusterShape,
+        MainloopScheduleType,
+        EpilogueScheduleType,
+        TileSchedulerType,
+        false>::Gemm;
+    return launch_sm90_fp8_scaled_mm<Gemm, false>(out, a, b, scales_a, scales_b, bias);
+  }
+}
+
+template <typename OutType>
+void sm90_fp8_dispatch_shape(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  uint32_t const m = a.size(0);
+  using FastPingpongScheduler = cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
+  using FastBasicScheduler = cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum;
+  using PersistentTileScheduler = cutlass::gemm::PersistentScheduler;
+  using BasicTileScheduler = void;
+  if (m <= 1) {
+    return sm90_fp8_dispatch_bias<
+        OutType,
+        Shape<_64, _64, _128>,
+        Shape<_1, _8, _1>,
+        FastBasicScheduler,
+        BasicTileScheduler>(out, a, b, scales_a, scales_b, bias);
+  }
+  if (m <= 64) {
+    // m in [1, 64]
+    return sm90_fp8_dispatch_bias<
+        OutType,
+        Shape<_64, _64, _128>,
+        Shape<_1, _4, _1>,
+        FastPingpongScheduler,
+        PersistentTileScheduler>(out, a, b, scales_a, scales_b, bias);
+  } else if (m <= 256) {
+    // m in (64, 256]
+    return sm90_fp8_dispatch_bias<
+        OutType,
+        Shape<_64, _64, _128>,
+        Shape<_1, _1, _1>,
+        FastPingpongScheduler,
+        PersistentTileScheduler>(out, a, b, scales_a, scales_b, bias);
+  } else if (m <= 1024) {
+    // m in (256, 1024]
+    return sm90_fp8_dispatch_bias<
+        OutType,
+        Shape<_128, _128, _128>,
+        Shape<_1, _1, _1>,
+        FastPingpongScheduler,
+        PersistentTileScheduler>(out, a, b, scales_a, scales_b, bias);
+  } else {
+    // m in (1024, inf)
+    return sm90_fp8_dispatch_bias<
+        OutType,
+        Shape<_128, _128, _128>,
+        Shape<_2, _1, _1>,
+        FastPingpongScheduler,
+        PersistentTileScheduler>(out, a, b, scales_a, scales_b, bias);
+  }
+}
+#endif
+
+#if defined CUDA_VERSION && CUDA_VERSION >= 12080
+template <
+    typename ElementType,
+    typename OutElementType,
+    typename AccumElementType,
+    typename CTAShape,
+    typename ClusterShape,
+    typename MainloopScheduleType,
+    typename EpilogueScheduleType,
+    typename TileSchedulerType = void,
+    bool WithBias = false>
+struct DeviceGemmFp8RowwiseSm100 {
+  static_assert(std::is_same_v<ElementType, cutlass::float_e4m3_t>, "ElementType must be FP8(e4m3)");
+  using TileShape = CTAShape;
+  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+
+  using ElementComputeEpilogue = float;
+  using ScaleA = cutlass::epilogue::fusion::Sm90ColBroadcast<
+      0,
+      TileShape,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cute::Stride<cute::Int<1>, cute::Int<0>, cute::Int<0>>>;
+
+  using ScaleB = cutlass::epilogue::fusion::Sm90RowBroadcast<
+      0,
+      TileShape,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
+
+  using Bias = cutlass::epilogue::fusion::Sm90RowBroadcast<
+      0,
+      TileShape,
+      OutElementType,
+      OutElementType,
+      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
+
+  using Compute0 = cutlass::epilogue::fusion::
+      Sm90Compute<cutlass::multiplies, float, float, cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute0 = cutlass::epilogue::fusion::Sm90EVT<Compute0, ScaleB, Accum>;
+
+  using LayoutA = cutlass::layout::RowMajor;
+  static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementType>::value;
+
+  using LayoutB = cutlass::layout::ColumnMajor;
+  static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementType>::value;
+
+  using ElementC = void;
+  using LayoutC = cutlass::layout::RowMajor;
+  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<OutElementType>::value;
+
+  using LayoutD = cutlass::layout::RowMajor;
+  static constexpr int AlignmentD = AlignmentC;
+
+  using Compute1MulAdd = cutlass::epilogue::fusion::
+      Sm90Compute<cutlass::multiply_add, OutElementType, float, cutlass::FloatRoundStyle::round_to_nearest>;
+  using Compute1Mul = cutlass::epilogue::fusion::
+      Sm90Compute<cutlass::multiplies, OutElementType, float, cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute = typename std::conditional_t<
+      WithBias,
+      cutlass::epilogue::fusion::Sm90EVT<Compute1MulAdd, ScaleA, EVTCompute0, Bias>,
+      cutlass::epilogue::fusion::Sm90EVT<Compute1Mul, ScaleA, EVTCompute0>>;
+  using ArgumentType = typename EVTCompute::Arguments;
+  // MMA type
+  using ElementAccumulator = AccumElementType;
+
+  // Epilogue types
+  using ElementCompute = float;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm100,
+      cutlass::arch::OpClassTensorOp,
+      TileShape,
+      ClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulator,
+      ElementCompute,
+      ElementC,
+      LayoutC,
+      AlignmentC,
+      OutElementType,
+      LayoutD,
+      AlignmentD,
+      EpilogueScheduleType,
+      EVTCompute>::CollectiveOp;
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm100,
+      cutlass::arch::OpClassTensorOp,
+      ElementType,
+      LayoutA,
+      AlignmentA,
+      ElementType,
+      LayoutB,
+      AlignmentB,
+      ElementAccumulator,
+      TileShape,
+      ClusterShape,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+          sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      MainloopScheduleType>::CollectiveOp;
+  using GemmKernel =
+      cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  template <typename Descriptor, typename T>
+  static auto args_from_tensor(torch::Tensor const& tensor) {
+    using Arguments = typename Descriptor::Arguments;
+    auto* data_ptr = static_cast<T*>(tensor.data_ptr());
+    static_assert(
+        std::is_same_v<Descriptor, ScaleA> || std::is_same_v<Descriptor, ScaleB> || std::is_same_v<Descriptor, Bias>);
+    return Arguments{data_ptr};
+  }
+
+ public:
+  static ArgumentType prepare_args(
+      torch::Tensor const& a_scales,
+      torch::Tensor const& b_scales,
+      std::optional<torch::Tensor> const& bias = std::nullopt) {
+    auto a_args = args_from_tensor<ScaleA, float>(a_scales);
+    auto b_args = args_from_tensor<ScaleB, float>(b_scales);
+
+    typename EVTCompute0::Arguments evt0_args{b_args, {}, {}};
+
+    if constexpr (WithBias) {
+      auto bias_args = args_from_tensor<Bias, OutElementType>(bias.value());
+      return ArgumentType{a_args, evt0_args, bias_args, {}};
+    } else {
+      return ArgumentType{a_args, evt0_args, {}};
+    }
+  }
+};
+
+template <typename GemmType, bool WithBias>
+typename GemmType::Gemm::Arguments prepare_sm100_fp8_args(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  using Gemm = typename GemmType::Gemm;
+  using ElementT = typename Gemm::ElementA;
+  using ElementC = typename Gemm::ElementC;
+  using ElementOutput = typename Gemm::ElementD;
+  using ElementComputeEpilogue = float;
+  using GemmKernel = typename Gemm::GemmKernel;
+
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using StrideC = typename Gemm::GemmKernel::StrideC;
+  using StrideD = StrideC;
+  using StrideAux = StrideC;
+
+  int32_t m = a.size(0);
+  int32_t n = b.size(1);
+  int32_t k = a.size(1);
+
+  ElementT const* ptr_a = reinterpret_cast<ElementT const*>(a.data_ptr());
+  ElementT const* ptr_b = reinterpret_cast<ElementT const*>(b.data_ptr());
+
+  StrideA stride_a = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(m, k, 1));
+  StrideB stride_b = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(n, k, 1));
+  StrideC stride_c = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(m, n, 1));
+  StrideD stride_d = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(m, n, 1));
+  StrideAux aux_stride = stride_d;
+
+  typename GemmKernel::MainloopArguments mainloop_args{ptr_a, stride_a, ptr_b, stride_b};
+
+  typename GemmKernel::ProblemShape prob_shape = {m, n, k, 1};
+  cutlass::KernelHardwareInfo hw_info;
+  typename GemmKernel::TileSchedulerArguments scheduler = {};
+
+  auto ptr_c = static_cast<ElementOutput*>(out.data_ptr());
+
+  auto prepare_epilogue_args = [&](const c10::optional<torch::Tensor>& bias = c10::nullopt) {
+    if constexpr (WithBias) {
+      TORCH_CHECK(bias.has_value(), "Bias tensor is required but not provided.");
+      return typename GemmKernel::EpilogueArguments{
+          GemmType::prepare_args(scales_a, scales_b, bias.value()), ptr_c, stride_c, ptr_c, stride_d};
+    } else {
+      return typename GemmKernel::EpilogueArguments{
+          GemmType::prepare_args(scales_a, scales_b), ptr_c, stride_c, ptr_c, stride_d};
+    }
+  };
+
+  typename GemmKernel::Arguments args{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      prob_shape,
+      mainloop_args,
+      prepare_epilogue_args(bias),
+      hw_info,
+      scheduler};
+  return args;
+}
+
+template <typename Gemm, bool WithBias>
+void launch_sm100_fp8_scaled_mm(
+    torch::Tensor& out,
+    torch::Tensor const& a,
+    torch::Tensor const& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  auto args = prepare_sm100_fp8_args<Gemm, WithBias>(out, a, b, scales_a, scales_b, bias);
+
+  typename Gemm::Gemm gemm_op;
+  size_t workspace_size = gemm_op.get_workspace_size(args);
+  auto const workspace_options = torch::TensorOptions().dtype(torch::kUInt8).device(a.device());
+  auto workspace = torch::empty(workspace_size, workspace_options);
+  auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
+  auto can_implement = gemm_op.can_implement(args);
+  TORCH_CHECK(can_implement == cutlass::Status::kSuccess)
+  auto status = gemm_op.run(args, workspace.data_ptr(), stream);
+  TORCH_CHECK(status == cutlass::Status::kSuccess)
+}
+
+template <typename OutType>
+void sm100_fp8_dispatch_bias(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  using CTAShapeDefault = Shape<_256, _128, _64>;
+  using ClusterShapeDefault = Shape<_2, _2, _1>;
+
+  using CTAShape256 = Shape<_128, _128, _128>;
+  using ClusterShape256 = Shape<_2, _1, _1>;
+
+  using CTAShape64 = Shape<_64, _64, _128>;
+  using ClusterShape64 = Shape<_1, _1, _1>;
+
+  using CTAShape16 = Shape<_64, _64, _128>;
+  using ClusterShape16 = Shape<_1, _4, _1>;
+
+  using MainloopScheduleType = cutlass::gemm::collective::KernelScheduleAuto;
+  using EpilogueScheduleType = cutlass::epilogue::collective::EpilogueScheduleAuto;
+  using TileSchedulerType = void;
+
+  using ElementInput = cutlass::float_e4m3_t;
+  using ElementOutput = OutType;
+  using AccumElementType = float;
+
+  // Gemm type with bias
+  using BiasGemmDefault = DeviceGemmFp8RowwiseSm100<
+      ElementInput,
+      ElementOutput,
+      AccumElementType,
+      CTAShapeDefault,
+      ClusterShapeDefault,
+      MainloopScheduleType,
+      EpilogueScheduleType,
+      TileSchedulerType,
+      true>;
+  using BiasGemm256 = DeviceGemmFp8RowwiseSm100<
+      ElementInput,
+      ElementOutput,
+      AccumElementType,
+      CTAShape256,
+      ClusterShape256,
+      MainloopScheduleType,
+      EpilogueScheduleType,
+      TileSchedulerType,
+      true>;
+  using BiasGemm64 = DeviceGemmFp8RowwiseSm100<
+      ElementInput,
+      ElementOutput,
+      AccumElementType,
+      CTAShape64,
+      ClusterShape64,
+      MainloopScheduleType,
+      EpilogueScheduleType,
+      TileSchedulerType,
+      true>;
+  using BiasGemm16 = DeviceGemmFp8RowwiseSm100<
+      ElementInput,
+      ElementOutput,
+      AccumElementType,
+      CTAShape16,
+      ClusterShape16,
+      MainloopScheduleType,
+      EpilogueScheduleType,
+      TileSchedulerType,
+      true>;
+
+  // Gemm type without bias
+  using GemmDefault = DeviceGemmFp8RowwiseSm100<
+      ElementInput,
+      ElementOutput,
+      AccumElementType,
+      CTAShapeDefault,
+      ClusterShapeDefault,
+      MainloopScheduleType,
+      EpilogueScheduleType,
+      TileSchedulerType,
+      false>;
+  using Gemm256 = DeviceGemmFp8RowwiseSm100<
+      ElementInput,
+      ElementOutput,
+      AccumElementType,
+      CTAShape256,
+      ClusterShape256,
+      MainloopScheduleType,
+      EpilogueScheduleType,
+      TileSchedulerType,
+      false>;
+  using Gemm64 = DeviceGemmFp8RowwiseSm100<
+      ElementInput,
+      ElementOutput,
+      AccumElementType,
+      CTAShape64,
+      ClusterShape64,
+      MainloopScheduleType,
+      EpilogueScheduleType,
+      TileSchedulerType,
+      false>;
+  using Gemm16 = DeviceGemmFp8RowwiseSm100<
+      ElementInput,
+      ElementOutput,
+      AccumElementType,
+      CTAShape16,
+      ClusterShape16,
+      MainloopScheduleType,
+      EpilogueScheduleType,
+      TileSchedulerType,
+      false>;
+
+  // next power of 2 (minimum 16)
+  uint32_t const m = a.size(0);
+  uint32_t const mp2 = std::max(static_cast<uint32_t>(16), next_pow_2(m));
+
+  if (bias) {
+    if (mp2 <= 16) {
+      // m in [1, 16]
+      return launch_sm100_fp8_scaled_mm<BiasGemm16, true>(out, a, b, scales_a, scales_b, bias);
+    } else if (mp2 <= 64) {
+      // m in (16, 64]
+      return launch_sm100_fp8_scaled_mm<BiasGemm64, true>(out, a, b, scales_a, scales_b, bias);
+    } else if (mp2 <= 256) {
+      // m in (64, 256]
+      return launch_sm100_fp8_scaled_mm<BiasGemm256, true>(out, a, b, scales_a, scales_b, bias);
+    } else {
+      // m in (256, inf]
+      return launch_sm100_fp8_scaled_mm<BiasGemmDefault, true>(out, a, b, scales_a, scales_b, bias);
+    }
+  } else {
+    if (mp2 <= 16) {
+      // m in [1, 16]
+      return launch_sm100_fp8_scaled_mm<Gemm16, false>(out, a, b, scales_a, scales_b, bias);
+    } else if (mp2 <= 64) {
+      // m in (16, 64]
+      return launch_sm100_fp8_scaled_mm<Gemm64, false>(out, a, b, scales_a, scales_b, bias);
+    } else if (mp2 <= 256) {
+      // m in (64, 256]
+      return launch_sm100_fp8_scaled_mm<Gemm256, false>(out, a, b, scales_a, scales_b, bias);
+    } else {
+      return launch_sm100_fp8_scaled_mm<GemmDefault, false>(out, a, b, scales_a, scales_b, bias);
+    }
+  }
+}
+
+template <typename OutType>
+void sm100_fp8_dispatch_shape(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  return sm100_fp8_dispatch_bias<OutType>(out, a, b, scales_a, scales_b, bias);
+}
+
+template <
+    typename ElementType,
+    typename OutElementType,
+    typename AccumElementType,
+    typename CTAShape,
+    typename ClusterShape,
+    typename MainloopScheduleType,
+    typename EpilogueScheduleType,
+    typename TileSchedulerType = void,
+    bool WithBias = false>
+struct DeviceGemmFp8RowwiseSm120 {
+  static_assert(std::is_same_v<ElementType, cutlass::float_e4m3_t>, "ElementType must be FP8(e4m3)");
+  using TileShape = CTAShape;
+  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+
+  using ElementComputeEpilogue = float;
+  using ScaleA = cutlass::epilogue::fusion::Sm90ColBroadcast<
+      0,
+      TileShape,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cute::Stride<cute::Int<1>, cute::Int<0>, cute::Int<0>>>;
+
+  using ScaleB = cutlass::epilogue::fusion::Sm90RowBroadcast<
+      0,
+      TileShape,
+      ElementComputeEpilogue,
+      ElementComputeEpilogue,
+      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
+
+  using Bias = cutlass::epilogue::fusion::Sm90RowBroadcast<
+      0,
+      TileShape,
+      OutElementType,
+      OutElementType,
+      cute::Stride<cute::Int<0>, cute::Int<1>, cute::Int<0>>>;
+
+  using Compute0 = cutlass::epilogue::fusion::
+      Sm90Compute<cutlass::multiplies, float, float, cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute0 = cutlass::epilogue::fusion::Sm90EVT<Compute0, ScaleB, Accum>;
+
+  using LayoutA = cutlass::layout::RowMajor;
+  static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementType>::value;
+
+  using LayoutB = cutlass::layout::ColumnMajor;
+  static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementType>::value;
+
+  using ElementC = void;
+  using LayoutC = cutlass::layout::RowMajor;
+  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<OutElementType>::value;
+
+  using LayoutD = cutlass::layout::RowMajor;
+  static constexpr int AlignmentD = AlignmentC;
+
+  using Compute1MulAdd = cutlass::epilogue::fusion::
+      Sm90Compute<cutlass::multiply_add, OutElementType, float, cutlass::FloatRoundStyle::round_to_nearest>;
+  using Compute1Mul = cutlass::epilogue::fusion::
+      Sm90Compute<cutlass::multiplies, OutElementType, float, cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute = typename std::conditional_t<
+      WithBias,
+      cutlass::epilogue::fusion::Sm90EVT<Compute1MulAdd, ScaleA, EVTCompute0, Bias>,
+      cutlass::epilogue::fusion::Sm90EVT<Compute1Mul, ScaleA, EVTCompute0>>;
+  using ArgumentType = typename EVTCompute::Arguments;
+  // MMA type
+  using ElementAccumulator = AccumElementType;
+
+  // Epilogue types
+  using ElementCompute = float;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm120,
+      cutlass::arch::OpClassTensorOp,
+      TileShape,
+      ClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulator,
+      ElementCompute,
+      ElementC,
+      LayoutC,
+      AlignmentC,
+      OutElementType,
+      LayoutD,
+      AlignmentD,
+      EpilogueScheduleType,
+      EVTCompute>::CollectiveOp;
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm120,
+      cutlass::arch::OpClassTensorOp,
+      ElementType,
+      LayoutA,
+      AlignmentA,
+      ElementType,
+      LayoutB,
+      AlignmentB,
+      ElementAccumulator,
+      TileShape,
+      ClusterShape,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+          sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      MainloopScheduleType>::CollectiveOp;
+  using GemmKernel =
+      cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  template <typename Descriptor, typename T>
+  static auto args_from_tensor(torch::Tensor const& tensor) {
+    using Arguments = typename Descriptor::Arguments;
+    auto* data_ptr = static_cast<T*>(tensor.data_ptr());
+    static_assert(
+        std::is_same_v<Descriptor, ScaleA> || std::is_same_v<Descriptor, ScaleB> || std::is_same_v<Descriptor, Bias>);
+    return Arguments{data_ptr};
+  }
+
+ public:
+  static ArgumentType prepare_args(
+      torch::Tensor const& a_scales,
+      torch::Tensor const& b_scales,
+      std::optional<torch::Tensor> const& bias = std::nullopt) {
+    auto a_args = args_from_tensor<ScaleA, float>(a_scales);
+    auto b_args = args_from_tensor<ScaleB, float>(b_scales);
+
+    typename EVTCompute0::Arguments evt0_args{b_args, {}, {}};
+
+    if constexpr (WithBias) {
+      auto bias_args = args_from_tensor<Bias, OutElementType>(bias.value());
+      return ArgumentType{a_args, evt0_args, bias_args, {}};
+    } else {
+      return ArgumentType{a_args, evt0_args, {}};
+    }
+  }
+};
+
+template <typename GemmType, bool WithBias>
+typename GemmType::Gemm::Arguments prepare_sm120_fp8_args(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  using Gemm = typename GemmType::Gemm;
+  using ElementT = typename Gemm::ElementA;
+  using ElementC = typename Gemm::ElementC;
+  using ElementOutput = typename Gemm::ElementD;
+  using ElementComputeEpilogue = float;
+  using GemmKernel = typename Gemm::GemmKernel;
+
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using StrideC = typename Gemm::GemmKernel::StrideC;
+  using StrideD = StrideC;
+  using StrideAux = StrideC;
+
+  int32_t m = a.size(0);
+  int32_t n = b.size(1);
+  int32_t k = a.size(1);
+
+  ElementT const* ptr_a = reinterpret_cast<ElementT const*>(a.data_ptr());
+  ElementT const* ptr_b = reinterpret_cast<ElementT const*>(b.data_ptr());
+
+  StrideA stride_a = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(m, k, 1));
+  StrideB stride_b = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(n, k, 1));
+  StrideC stride_c = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(m, n, 1));
+  StrideD stride_d = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(m, n, 1));
+  StrideAux aux_stride = stride_d;
+
+  typename GemmKernel::MainloopArguments mainloop_args{ptr_a, stride_a, ptr_b, stride_b};
+
+  typename GemmKernel::ProblemShape prob_shape = {m, n, k, 1};
+  cutlass::KernelHardwareInfo hw_info;
+  typename GemmKernel::TileSchedulerArguments scheduler = {};
+
+  auto ptr_c = static_cast<ElementOutput*>(out.data_ptr());
+
+  auto prepare_epilogue_args = [&](const c10::optional<torch::Tensor>& bias = c10::nullopt) {
+    if constexpr (WithBias) {
+      TORCH_CHECK(bias.has_value(), "Bias tensor is required but not provided.");
+      return typename GemmKernel::EpilogueArguments{
+          GemmType::prepare_args(scales_a, scales_b, bias.value()), ptr_c, stride_c, ptr_c, stride_d};
+    } else {
+      return typename GemmKernel::EpilogueArguments{
+          GemmType::prepare_args(scales_a, scales_b), ptr_c, stride_c, ptr_c, stride_d};
+    }
+  };
+
+  typename GemmKernel::Arguments args{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      prob_shape,
+      mainloop_args,
+      prepare_epilogue_args(bias),
+      hw_info,
+      scheduler};
+  return args;
+}
+
+template <typename Gemm, bool WithBias>
+void launch_sm120_fp8_scaled_mm(
+    torch::Tensor& out,
+    torch::Tensor const& a,
+    torch::Tensor const& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  auto args = prepare_sm120_fp8_args<Gemm, WithBias>(out, a, b, scales_a, scales_b, bias);
+
+  typename Gemm::Gemm gemm_op;
+  size_t workspace_size = gemm_op.get_workspace_size(args);
+  auto const workspace_options = torch::TensorOptions().dtype(torch::kUInt8).device(a.device());
+  auto workspace = torch::empty(workspace_size, workspace_options);
+  auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
+  auto can_implement = gemm_op.can_implement(args);
+  TORCH_CHECK(can_implement == cutlass::Status::kSuccess)
+  auto status = gemm_op.run(args, workspace.data_ptr(), stream);
+  TORCH_CHECK(status == cutlass::Status::kSuccess)
+}
+
+template <typename OutType>
+void sm120_fp8_dispatch_bias(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  using CTAShapeDefault = Shape<_128, _128, _128>;
+  using ClusterShapeDefault = Shape<_1, _1, _1>;
+
+  using MainloopScheduleType = cutlass::gemm::collective::KernelScheduleAuto;
+  using EpilogueScheduleType = cutlass::epilogue::collective::EpilogueScheduleAuto;
+  using TileSchedulerType = void;
+
+  using ElementInput = cutlass::float_e4m3_t;
+  using ElementOutput = OutType;
+  using AccumElementType = float;
+
+  using BiasGemmDefault = DeviceGemmFp8RowwiseSm120<
+      ElementInput,
+      ElementOutput,
+      AccumElementType,
+      CTAShapeDefault,
+      ClusterShapeDefault,
+      MainloopScheduleType,
+      EpilogueScheduleType,
+      TileSchedulerType,
+      true>;
+
+  using GemmDefault = DeviceGemmFp8RowwiseSm120<
+      ElementInput,
+      ElementOutput,
+      AccumElementType,
+      CTAShapeDefault,
+      ClusterShapeDefault,
+      MainloopScheduleType,
+      EpilogueScheduleType,
+      TileSchedulerType,
+      false>;
+
+  if (bias) {
+    return launch_sm120_fp8_scaled_mm<BiasGemmDefault, true>(out, a, b, scales_a, scales_b, bias);
+  } else {
+    return launch_sm120_fp8_scaled_mm<GemmDefault, false>(out, a, b, scales_a, scales_b, bias);
+  }
+}
+
+template <typename OutType>
+void sm120_fp8_dispatch_shape(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
+  return sm120_fp8_dispatch_bias<OutType>(out, a, b, scales_a, scales_b, bias);
+}
+#endif
+
+torch::Tensor fp8_scaled_mm_impl(
+    const torch::Tensor& mat_a,
+    const torch::Tensor& mat_b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const torch::Dtype& out_dtype,
+    const c10::optional<torch::Tensor>& bias) {
+  TORCH_CHECK(mat_a.is_cuda(), "mat_a must be a CUDA tensor");
+  TORCH_CHECK(mat_b.is_cuda(), "mat_b must be a CUDA tensor");
+  TORCH_CHECK(mat_a.dim() == 2, "mat_a must be a 2D tensor");
+  TORCH_CHECK(mat_b.dim() == 2, "mat_b must be a 2D tensor");
+  TORCH_CHECK(mat_a.stride(1) == 1, "mat_a must be a row major tensor");
+  TORCH_CHECK(mat_b.stride(0) == 1, "mat_b must be a column major tensor");
+  TORCH_CHECK(mat_a.size(1) == mat_b.size(0), "mat_a and mat_b shapes cannot be multiplied");
+
+  TORCH_CHECK(
+      (mat_a.size(1) * mat_a.element_size()) % 16 == 0, "mat_a must be multiple of 16 bytes for memory alignment");
+  TORCH_CHECK(
+      (mat_b.size(0) * mat_b.element_size()) % 16 == 0, "mat_b must be multiple of 16 bytes for memory alignment");
+  TORCH_CHECK(mat_a.scalar_type() == torch::kFloat8_e4m3fn, "mat_a must be Float8_e4m3fn");
+  TORCH_CHECK(mat_b.scalar_type() == torch::kFloat8_e4m3fn, "mat_b must be Float8_e4m3fn");
+  TORCH_CHECK(out_dtype == torch::kHalf || out_dtype == torch::kBFloat16, "out_dtype must be Half or BFloat16");
+
+  TORCH_CHECK(scales_a.numel() == mat_a.size(0), "size of scales_a is not matched");
+  TORCH_CHECK(scales_b.numel() == mat_b.size(1), "size of scales_b is not matched");
+  TORCH_CHECK(scales_a.is_contiguous(), "scales_a must be contiguous");
+  TORCH_CHECK(scales_b.is_contiguous(), "scales_b msut be contiguous");
+  TORCH_CHECK(scales_a.scalar_type() == torch::kFloat32, "scales_a must be Float32");
+  TORCH_CHECK(scales_b.scalar_type() == torch::kFloat32, "scales_b must be Float32");
+
+  if (bias) {
+    TORCH_CHECK(bias->numel() == mat_b.size(1), "size of bias is not matched");
+    TORCH_CHECK(bias->is_contiguous(), "bias must be contiguous");
+    TORCH_CHECK(bias->dtype() == out_dtype, "bias dtype must match output dtype");
+  }
+
+  torch::Tensor out = torch::empty({mat_a.size(0), mat_b.size(1)}, mat_a.options().dtype(out_dtype));
+  TORCH_CHECK((out.size(1) * out.element_size()) % 16 == 0, "out must be multiple of 16 bytes for memory alignment");
+
+  auto sm_version = getSMVersion();
+
+#if defined CUDA_VERSION && CUDA_VERSION >= 12080
+  if (sm_version >= 120) {
+    if (out_dtype == torch::kBFloat16) {
+      sm120_fp8_dispatch_shape<cutlass::bfloat16_t>(out, mat_a, mat_b, scales_a, scales_b, bias);
+    } else {
+      sm120_fp8_dispatch_shape<cutlass::half_t>(out, mat_a, mat_b, scales_a, scales_b, bias);
+    }
+    return out;
+  } else if (sm_version >= 100) {
+    if (out_dtype == torch::kBFloat16) {
+      sm100_fp8_dispatch_shape<cutlass::bfloat16_t>(out, mat_a, mat_b, scales_a, scales_b, bias);
+    } else {
+      sm100_fp8_dispatch_shape<cutlass::half_t>(out, mat_a, mat_b, scales_a, scales_b, bias);
+    }
+    return out;
+  }
+#endif
+
+#if defined CUDA_VERSION && CUDA_VERSION >= 12000
+  if (sm_version >= 90) {
+    if (out_dtype == torch::kBFloat16) {
+      sm90_fp8_dispatch_shape<cutlass::bfloat16_t>(out, mat_a, mat_b, scales_a, scales_b, bias);
+    } else {
+      sm90_fp8_dispatch_shape<cutlass::half_t>(out, mat_a, mat_b, scales_a, scales_b, bias);
+    }
+    return out;
+  }
+#endif
+
+#if defined CUDA_VERSION && CUDA_VERSION >= 12040
+  if (sm_version == 89) {
+    if (out_dtype == torch::kBFloat16) {
+      sm89_fp8_dispatch_shape<cutlass::bfloat16_t>(out, mat_a, mat_b, scales_a, scales_b, bias);
+    } else {
+      sm89_fp8_dispatch_shape<cutlass::half_t>(out, mat_a, mat_b, scales_a, scales_b, bias);
+    }
+    return out;
+  }
+#endif
+
+  TORCH_CHECK_NOT_IMPLEMENTED(false, "No implemented fp8_scaled_mm for current compute capability: ", sm_version);
+}
+
+namespace joyomni_ops {
+
+// Namespaced entry matching pybind.cpp. mat_b is column-major (K-major) fp8;
+// scales_a per-row (M), scales_b per-col (N); out_dtype half/bf16.
+torch::Tensor fp8_scaled_mm(
+    const torch::Tensor& mat_a,
+    const torch::Tensor& mat_b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const torch::ScalarType& out_dtype,
+    const c10::optional<torch::Tensor>& bias) {
+  return ::fp8_scaled_mm_impl(mat_a, mat_b, scales_a, scales_b, out_dtype, bias);
+}
+
+}  // namespace joyomni_ops

--- a/joyomni_ops/csrc/fused_norm_scale_shift.cu
+++ b/joyomni_ops/csrc/fused_norm_scale_shift.cu
@@ -1,0 +1,211 @@
+/*
+ * Fused (Layer|RMS)Norm + adaLN scale/shift, bf16/fp16/fp32.
+ *   out = Norm(x; gamma, beta) * (1 + scale) + shift
+ *
+ * Trimmed from the JoyOmni sgl-kernel fork (SGLang Team, Apache-2.0) to the
+ * single [M, N] per-row scale/shift path the pipeline uses; cutlass dependency
+ * removed (native __nv_bfloat16 instead of cutlass::bfloat16_t).
+ *
+ * x:            [M, N]  (row-contiguous)
+ * gamma/beta:   None or [N]   (affine; beta only for LayerNorm)
+ * scale/shift:  [M, N]  (per row) — one modulation vector per token row
+ * norm_type:    0 = LayerNorm, 1 = RMSNorm
+ */
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "joyomni_ops.h"
+
+namespace joyomni_ops {
+namespace {
+
+enum NormType : int { kLayerNorm = 0, kRMSNorm = 1 };
+
+template <typename T, int NumVals>
+__device__ __forceinline__ void warpReduceSum(T (&vals)[NumVals]) {
+  unsigned mask = 0xffffffffu;
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1)
+#pragma unroll
+    for (int i = 0; i < NumVals; ++i) vals[i] += __shfl_down_sync(mask, vals[i], offset);
+}
+
+template <typename T, int NumVals>
+__device__ __forceinline__ void blockReduceSum(T (&vals)[NumVals]) {
+  __shared__ T shared[32][NumVals];
+  int lane = threadIdx.x & 31;
+  int wid = threadIdx.x >> 5;
+  warpReduceSum<T, NumVals>(vals);
+  if (lane == 0)
+#pragma unroll
+    for (int i = 0; i < NumVals; ++i) shared[wid][i] = vals[i];
+  __syncthreads();
+  if (wid == 0) {
+    T acc[NumVals];
+#pragma unroll
+    for (int i = 0; i < NumVals; ++i) acc[i] = T(0);
+    int num_warps = (blockDim.x + 31) / 32;
+#pragma unroll
+    for (int w = 0; w < 32; ++w)
+      if (w < num_warps)
+#pragma unroll
+        for (int i = 0; i < NumVals; ++i) acc[i] += shared[w][i];
+#pragma unroll
+    for (int i = 0; i < NumVals; ++i) vals[i] = acc[i];
+  }
+  __syncthreads();
+}
+
+// Vec-of-4 element types.
+struct alignas(8) bf16_4 { __nv_bfloat16 x, y, z, w; };
+struct alignas(8) half4 { __half x, y, z, w; };
+
+template <typename T4_, typename T_>
+struct DTypeTag { using T4 = T4_; using T = T_; };
+
+// One block per row (m_idx). scale/shift indexed per-row [M, N].
+template <typename T4, typename T, int ITEM_PER_THREAD, int norm_type>
+__global__ void normScaleShiftPerRow(
+    T4* output, const T4* input, const T4* gamma, const T4* beta,
+    const T4* scale, const T4* shift, const int n, bool affine, float eps) {
+  const int m_idx = blockIdx.x;
+  const int tid = threadIdx.x;
+  const int bdimx = blockDim.x;
+  __shared__ float s_mean, s_variance;
+  float local_sums[1] = {0.0f};
+  T4 local_val[ITEM_PER_THREAD];
+  const int n_4 = n / 4;
+  const int offset = m_idx * n_4;
+  input += offset;
+  output += offset;
+  scale += offset;  // per-row
+  shift += offset;
+
+  const T4 zero = {T(0.0f), T(0.0f), T(0.0f), T(0.0f)};
+#pragma unroll
+  for (int i = 0; i < ITEM_PER_THREAD; ++i) {
+    const int index = i * bdimx + tid;
+    local_val[i] = index < n_4 ? input[index] : zero;
+    if constexpr (norm_type == kLayerNorm) {
+      local_sums[0] += float(local_val[i].x) + float(local_val[i].y) + float(local_val[i].z) + float(local_val[i].w);
+    } else {
+      local_sums[0] += float(local_val[i].x) * float(local_val[i].x) + float(local_val[i].y) * float(local_val[i].y) +
+                       float(local_val[i].z) * float(local_val[i].z) + float(local_val[i].w) * float(local_val[i].w);
+    }
+  }
+  if (blockDim.x <= 32) warpReduceSum<float, 1>(local_sums);
+  else blockReduceSum<float, 1>(local_sums);
+  if (tid == 0) s_mean = local_sums[0] / n;
+  __syncthreads();
+
+  if constexpr (norm_type == kLayerNorm) {
+    local_sums[0] = 0.0f;
+#pragma unroll
+    for (int i = 0; i < ITEM_PER_THREAD; ++i) {
+      const int index = i * bdimx + tid;
+      if (index < n_4) {
+        float4 t = {float(local_val[i].x) - s_mean, float(local_val[i].y) - s_mean,
+                    float(local_val[i].z) - s_mean, float(local_val[i].w) - s_mean};
+        local_sums[0] += t.x * t.x + t.y * t.y + t.z * t.z + t.w * t.w;
+      }
+    }
+    if (blockDim.x <= 32) warpReduceSum<float, 1>(local_sums);
+    else blockReduceSum<float, 1>(local_sums);
+  }
+  if (tid == 0) s_variance = rsqrtf(local_sums[0] / n + eps);  // rms: rsqrt(mean(x^2)+eps)
+  __syncthreads();
+
+#pragma unroll
+  for (int i = 0; i < ITEM_PER_THREAD; ++i) {
+    const int index = i * bdimx + tid;
+    if (index >= n_4) continue;
+    const T4 g = affine ? gamma[index] : T4{T(1.f), T(1.f), T(1.f), T(1.f)};
+    const T4 sc = scale[index];
+    const T4 sh = shift[index];
+    T4 out;
+    if constexpr (norm_type == kLayerNorm) {
+      const T4 b = affine ? beta[index] : T4{T(0.f), T(0.f), T(0.f), T(0.f)};
+      out.x = T(((float(local_val[i].x) - s_mean) * s_variance * float(g.x) + float(b.x)) * (1.f + float(sc.x)) + float(sh.x));
+      out.y = T(((float(local_val[i].y) - s_mean) * s_variance * float(g.y) + float(b.y)) * (1.f + float(sc.y)) + float(sh.y));
+      out.z = T(((float(local_val[i].z) - s_mean) * s_variance * float(g.z) + float(b.z)) * (1.f + float(sc.z)) + float(sh.z));
+      out.w = T(((float(local_val[i].w) - s_mean) * s_variance * float(g.w) + float(b.w)) * (1.f + float(sc.w)) + float(sh.w));
+    } else {
+      out.x = T((float(local_val[i].x) * s_variance * float(g.x)) * (1.f + float(sc.x)) + float(sh.x));
+      out.y = T((float(local_val[i].y) * s_variance * float(g.y)) * (1.f + float(sc.y)) + float(sh.y));
+      out.z = T((float(local_val[i].z) * s_variance * float(g.z)) * (1.f + float(sc.z)) + float(sh.z));
+      out.w = T((float(local_val[i].w) * s_variance * float(g.w)) * (1.f + float(sc.w)) + float(sh.w));
+    }
+    output[index] = out;
+  }
+}
+
+template <typename DT>
+void launch(const torch::Tensor& x, void* gamma_ptr, void* beta_ptr, const torch::Tensor& scale,
+            const torch::Tensor& shift, torch::Tensor& y, int norm_type, bool affine, float eps) {
+  using T4 = typename DT::T4;
+  using T = typename DT::T;
+  const int64_t M = x.size(0), N = x.size(1);
+  dim3 grid((unsigned)M);
+  dim3 block;
+  auto stream = at::cuda::getCurrentCUDAStream();
+#define LAUNCH(IPT, NT)                                                                        \
+  normScaleShiftPerRow<T4, T, IPT, NT><<<grid, block, 0, stream>>>(                            \
+      (T4*)y.data_ptr(), (const T4*)x.data_ptr(), (const T4*)gamma_ptr, (const T4*)beta_ptr,   \
+      (const T4*)scale.data_ptr(), (const T4*)shift.data_ptr(), (int)N, affine, eps)
+  if (N <= 4096) {
+    block.x = (unsigned)((N / 4 + 31) / 32 * 32);
+    if (block.x > 1024) block.x = 1024;
+    if (norm_type == kLayerNorm) { LAUNCH(1, kLayerNorm); } else { LAUNCH(1, kRMSNorm); }
+  } else {
+    block.x = (unsigned)(((N + 7) / 8 + 31) / 32 * 32);
+    if (block.x > 1024) block.x = 1024;
+    if (norm_type == kLayerNorm) { LAUNCH(8, kLayerNorm); } else { LAUNCH(8, kRMSNorm); }
+  }
+#undef LAUNCH
+}
+
+}  // namespace
+
+torch::Tensor fused_norm_scale_shift(
+    const torch::Tensor& x, const c10::optional<torch::Tensor>& gamma_opt,
+    const c10::optional<torch::Tensor>& beta_opt, const torch::Tensor& scale,
+    const torch::Tensor& shift, int64_t norm_type, double eps) {
+  JO_CHECK_CUDA(x);
+  JO_CHECK_CUDA(scale);
+  JO_CHECK_CUDA(shift);
+  TORCH_CHECK(x.dim() == 2, "x must be 2D [M, N]");
+  TORCH_CHECK(x.stride(-1) == 1, "x last dim must be contiguous");
+  const int64_t M = x.size(0), N = x.size(1);
+  TORCH_CHECK((N % 4) == 0, "N must be divisible by 4");
+  TORCH_CHECK(scale.dim() == 2 && shift.dim() == 2, "scale/shift must be 2D [M, N]");
+  TORCH_CHECK(scale.size(0) == M && shift.size(0) == M, "scale/shift rows must equal M (per-row modulation)");
+  TORCH_CHECK(scale.size(1) == N && shift.size(1) == N, "scale/shift last dim must be N");
+  TORCH_CHECK(scale.stride(-1) == 1 && shift.stride(-1) == 1, "scale/shift last dim must be contiguous");
+  TORCH_CHECK(x.dtype() == scale.dtype() && x.dtype() == shift.dtype(), "x/scale/shift dtype must match");
+  TORCH_CHECK(norm_type == 0 || norm_type == 1, "norm_type must be 0 (layer) or 1 (rms)");
+
+  bool has_gamma = gamma_opt.has_value() && gamma_opt->defined();
+  bool has_beta = beta_opt.has_value() && beta_opt->defined();
+  bool affine = has_gamma;
+  void* gamma_ptr = has_gamma ? gamma_opt->data_ptr() : nullptr;
+  void* beta_ptr = has_beta ? beta_opt->data_ptr() : nullptr;
+  if (has_gamma) TORCH_CHECK(gamma_opt->numel() == N, "gamma must be length N");
+  if (has_beta) TORCH_CHECK(beta_opt->numel() == N, "beta must be length N");
+
+  const c10::cuda::CUDAGuard guard(x.device());
+  auto y = torch::empty_like(x);
+  if (x.dtype() == torch::kFloat32)
+    launch<DTypeTag<float4, float>>(x, gamma_ptr, beta_ptr, scale, shift, y, (int)norm_type, affine, (float)eps);
+  else if (x.dtype() == torch::kFloat16)
+    launch<DTypeTag<half4, __half>>(x, gamma_ptr, beta_ptr, scale, shift, y, (int)norm_type, affine, (float)eps);
+  else if (x.dtype() == torch::kBFloat16)
+    launch<DTypeTag<bf16_4, __nv_bfloat16>>(x, gamma_ptr, beta_ptr, scale, shift, y, (int)norm_type, affine, (float)eps);
+  else
+    TORCH_CHECK(false, "Unsupported dtype; use float32/float16/bfloat16");
+  return y;
+}
+
+}  // namespace joyomni_ops

--- a/joyomni_ops/csrc/fused_qknorm_rope_3d_kernel.cu
+++ b/joyomni_ops/csrc/fused_qknorm_rope_3d_kernel.cu
@@ -1,0 +1,210 @@
+/*
+ * Fused QK-Norm + 3D RoPE kernel for DiT video models (bf16).
+ * Applies per-head RMSNorm then interleaved RoPE using precomputed cos/sin.
+ *
+ * Adapted from the JoyOmni sgl-kernel fork (Apache-2.0, NVIDIA copyright below);
+ * trimmed to the single `_paired` entry point actually used by the pipeline.
+ *
+ * Copyright (c) 2025, NVIDIA CORPORATION. Licensed under the Apache License 2.0.
+ *
+ * Tensor layout: q/k are [batch, seq_len * num_heads, head_dim] bf16.
+ * cos/sin: [seq_len, head_dim/2] bf16.  weight: [head_dim] bf16.
+ */
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <torch/all.h>
+
+#include "joyomni_ops.h"
+
+namespace joyomni_ops {
+namespace {
+
+constexpr unsigned kFullMask = 0xffffffffu;
+
+template <typename T, int num>
+struct packed_as;
+template <>
+struct packed_as<unsigned, 1> {
+  using type = unsigned;
+};
+template <>
+struct packed_as<unsigned, 2> {
+  using type = uint2;
+};
+template <>
+struct packed_as<unsigned, 4> {
+  using type = uint4;
+};
+
+__inline__ __device__ float warpReduceSum(float val) {
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1)
+    val += __shfl_xor_sync(kFullMask, val, mask, 32);
+  return val;
+}
+
+template <typename T>
+inline __device__ __host__ T divUp(T m, T n) {
+  return (m + n - 1) / n;
+}
+
+// One warp normalizes+rotates one head. Q and K are packed into a single grid:
+// warps [0, N) handle Q, warps [N, 2N) handle K, where N = batch*seq*heads.
+template <int head_dim>
+__global__ void fusedQKNormRope3DPaired(
+    __nv_bfloat16* __restrict__ q,
+    __nv_bfloat16* __restrict__ k,
+    int const batch_size,
+    int const seq_len,
+    int const num_heads,
+    float const eps,
+    __nv_bfloat16 const* __restrict__ q_weight,
+    __nv_bfloat16 const* __restrict__ k_weight,
+    __nv_bfloat16 const* __restrict__ cos_ptr,
+    __nv_bfloat16 const* __restrict__ sin_ptr) {
+  int const warpsPerBlock = blockDim.x / 32;
+  int const warpId = threadIdx.x / 32;
+  int const laneId = threadIdx.x % 32;
+  int const globalWarpIdx = blockIdx.x * warpsPerBlock + warpId;
+
+  int const total_qk_heads = batch_size * seq_len * num_heads * 2;
+  if (globalWarpIdx >= total_qk_heads) return;
+
+  int const is_k = globalWarpIdx / (batch_size * seq_len * num_heads);
+  int const local_idx = globalWarpIdx % (batch_size * seq_len * num_heads);
+  int const batch_idx = local_idx / (seq_len * num_heads);
+  int const remaining = local_idx % (seq_len * num_heads);
+  int const token_idx = remaining / num_heads;
+  int const head_idx = remaining % num_heads;
+
+  static_assert(head_dim % (32 * 2) == 0, "head_dim must be divisible by 64");
+  constexpr int numElemsPerThread = head_dim / 32;
+  float elements[numElemsPerThread];
+  constexpr int elemSizeBytes = numElemsPerThread * sizeof(__nv_bfloat16);
+  static_assert(elemSizeBytes % 4 == 0, "elemSizeBytes must be a multiple of 4");
+  constexpr int vecSize = elemSizeBytes / 4;
+  using vec_T = typename packed_as<unsigned, vecSize>::type;
+
+  __nv_bfloat16* qk = is_k ? k : q;
+  __nv_bfloat16 const* weight = is_k ? k_weight : q_weight;
+
+  int const offsetWarp = batch_idx * seq_len * num_heads * head_dim +
+                         (token_idx * num_heads + head_idx) * head_dim;
+  int const offsetThread = offsetWarp + laneId * numElemsPerThread;
+
+  float sumOfSquares = 0.0f;
+  {
+    vec_T vec = *reinterpret_cast<vec_T const*>(&qk[offsetThread]);
+#pragma unroll
+    for (int i = 0; i < vecSize; i++) {
+      float2 vals = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162*>(reinterpret_cast<unsigned*>(&vec) + i));
+      sumOfSquares += vals.x * vals.x;
+      sumOfSquares += vals.y * vals.y;
+      elements[2 * i] = vals.x;
+      elements[2 * i + 1] = vals.y;
+    }
+  }
+
+  sumOfSquares = warpReduceSum(sumOfSquares);
+  float rms_rcp = rsqrtf(sumOfSquares / static_cast<float>(head_dim) + eps);
+
+#pragma unroll
+  for (int i = 0; i < numElemsPerThread; i++) {
+    int dim = laneId * numElemsPerThread + i;
+    elements[i] *= rms_rcp * __bfloat162float(weight[dim]);
+  }
+
+  int const cos_sin_row_offset = token_idx * (head_dim / 2);
+  float rotated[numElemsPerThread];
+#pragma unroll
+  for (int i = 0; i < numElemsPerThread; i += 2) {
+    int dim_idx = laneId * numElemsPerThread + i;
+    int cos_sin_idx = dim_idx / 2;
+    float c = __bfloat162float(cos_ptr[cos_sin_row_offset + cos_sin_idx]);
+    float s = __bfloat162float(sin_ptr[cos_sin_row_offset + cos_sin_idx]);
+    float x1 = elements[i];
+    float x2 = elements[i + 1];
+    rotated[i] = x1 * c - x2 * s;
+    rotated[i + 1] = x1 * s + x2 * c;
+  }
+
+  {
+    vec_T vec;
+#pragma unroll
+    for (int i = 0; i < vecSize; i++) {
+      __nv_bfloat162 vals = __float22bfloat162_rn(make_float2(rotated[2 * i], rotated[2 * i + 1]));
+      reinterpret_cast<__nv_bfloat162&>(*(reinterpret_cast<unsigned*>(&vec) + i)) = vals;
+    }
+    *reinterpret_cast<vec_T*>(&qk[offsetThread]) = vec;
+  }
+}
+
+void launchPaired(
+    void* q, void* k, int batch_size, int seq_len, int num_heads, int head_dim,
+    float eps, void const* q_weight, void const* k_weight, void const* cos_ptr,
+    void const* sin_ptr, cudaStream_t stream) {
+  constexpr int blockSize = 256;
+  int const warpsPerBlock = blockSize / 32;
+  int const totalQKHeads = batch_size * seq_len * num_heads * 2;
+  dim3 gridDim(divUp(totalQKHeads, warpsPerBlock));
+  dim3 blockDim(blockSize);
+  auto q16 = reinterpret_cast<__nv_bfloat16*>(q);
+  auto k16 = reinterpret_cast<__nv_bfloat16*>(k);
+  auto qw = reinterpret_cast<__nv_bfloat16 const*>(q_weight);
+  auto kw = reinterpret_cast<__nv_bfloat16 const*>(k_weight);
+  auto cs = reinterpret_cast<__nv_bfloat16 const*>(cos_ptr);
+  auto sn = reinterpret_cast<__nv_bfloat16 const*>(sin_ptr);
+#define LAUNCH(HD)                                                                            \
+  fusedQKNormRope3DPaired<HD><<<gridDim, blockDim, 0, stream>>>(                              \
+      q16, k16, batch_size, seq_len, num_heads, eps, qw, kw, cs, sn);                         \
+  break
+  switch (head_dim) {
+    case 64:
+      LAUNCH(64);
+    case 128:
+      LAUNCH(128);
+    case 256:
+      LAUNCH(256);
+    default:
+      TORCH_CHECK(false, "Unsupported head_dim for fused_qk_norm_rope_3d_paired: ", head_dim);
+  }
+#undef LAUNCH
+}
+
+}  // namespace
+
+void fused_qk_norm_rope_3d_paired(
+    torch::Tensor& q, torch::Tensor& k, int64_t seq_len, int64_t num_heads,
+    double eps, torch::Tensor& q_weight, torch::Tensor& k_weight,
+    torch::Tensor& cos, torch::Tensor& sin) {
+  TORCH_CHECK(q.dim() == 3, "q must be 3D [batch, seq_len*num_heads, head_dim]");
+  TORCH_CHECK(k.dim() == 3, "k must be 3D [batch, seq_len*num_heads, head_dim]");
+  TORCH_CHECK(q.sizes() == k.sizes(), "q and k must have the same shape");
+  TORCH_CHECK(q_weight.dim() == 1 && k_weight.dim() == 1, "weights must be 1D [head_dim]");
+  TORCH_CHECK(cos.dim() == 2 && sin.dim() == 2, "cos/sin must be 2D [seq_len, head_dim/2]");
+  JO_CHECK_INPUT(q, torch::kBFloat16);
+  JO_CHECK_INPUT(k, torch::kBFloat16);
+  JO_CHECK_INPUT(q_weight, torch::kBFloat16);
+  JO_CHECK_INPUT(k_weight, torch::kBFloat16);
+  JO_CHECK_INPUT(cos, torch::kBFloat16);
+  JO_CHECK_INPUT(sin, torch::kBFloat16);
+
+  int64_t batch_size = q.size(0);
+  int64_t head_dim = q.size(2);
+  TORCH_CHECK(q.size(1) == seq_len * num_heads, "q.size(1) must equal seq_len*num_heads");
+  TORCH_CHECK(q_weight.size(0) == head_dim && k_weight.size(0) == head_dim, "weight size must match head_dim");
+  TORCH_CHECK(cos.size(0) == seq_len && cos.size(1) == head_dim / 2, "cos shape must be [seq_len, head_dim/2]");
+  TORCH_CHECK(sin.size(0) == seq_len && sin.size(1) == head_dim / 2, "sin shape must be [seq_len, head_dim/2]");
+
+  const c10::cuda::CUDAGuard guard(q.device());
+  auto stream = at::cuda::getCurrentCUDAStream(q.get_device());
+  launchPaired(
+      q.data_ptr(), k.data_ptr(), static_cast<int>(batch_size), static_cast<int>(seq_len),
+      static_cast<int>(num_heads), static_cast<int>(head_dim), static_cast<float>(eps),
+      q_weight.data_ptr(), k_weight.data_ptr(), cos.data_ptr(), sin.data_ptr(), stream);
+}
+
+}  // namespace joyomni_ops

--- a/joyomni_ops/csrc/per_token_quant_fp8.cu
+++ b/joyomni_ops/csrc/per_token_quant_fp8.cu
@@ -1,0 +1,178 @@
+/*
+ * Dynamic per-token FP8 (e4m3) quantization.
+ *   For each row (token): scale = max(|x|) / 448;  q = round(x / scale) as fp8_e4m3.
+ * Self-contained: no flashinfer / cutlass. bf16 or fp16 input.
+ *
+ *   input:    [num_tokens, hidden_dim]  bf16/fp16
+ *   output_q: [num_tokens, hidden_dim]  fp8_e4m3 (torch.float8_e4m3fn)
+ *   output_s: [num_tokens]              float32 (per-token scale)
+ */
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+
+#include "joyomni_ops.h"
+
+namespace joyomni_ops {
+namespace {
+
+constexpr float kFP8E4M3Max = 448.0f;
+constexpr int kWarpSize = 32;
+
+__device__ __forceinline__ float warpReduceMax(float v) {
+#pragma unroll
+  for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, o, 32));
+  return v;
+}
+
+__device__ __forceinline__ float blockReduceMax(float v) {
+  __shared__ float sh[32];
+  int lane = threadIdx.x & 31, wid = threadIdx.x >> 5;
+  v = warpReduceMax(v);
+  if (lane == 0) sh[wid] = v;
+  __syncthreads();
+  int nwarps = (blockDim.x + 31) / 32;
+  v = (lane < nwarps) ? sh[lane] : 0.0f;
+  if (wid == 0) v = warpReduceMax(v);
+  return v;
+}
+
+// One warp per token; kTokensPerCTA warps per block. Vectorized by kVec.
+template <typename T, int kTokensPerCTA, int kVec>
+__global__ void perTokenQuantWarp(
+    const T* __restrict__ input, __nv_fp8_e4m3* __restrict__ out_q, float* __restrict__ out_s,
+    const int64_t hidden_dim, const int64_t num_tokens) {
+  const int warp_id = threadIdx.x / kWarpSize;
+  const int lane_id = threadIdx.x & (kWarpSize - 1);
+  const int token_id = blockIdx.x * kTokensPerCTA + warp_id;
+  if (token_id >= num_tokens) return;
+
+  const T* trow = input + token_id * hidden_dim;
+  __nv_fp8_e4m3* orow = out_q + token_id * hidden_dim;
+  const int num_vec = hidden_dim / kVec;
+
+  float max_value = 0.f;
+  for (int i = lane_id; i < num_vec; i += kWarpSize) {
+    const T* p = trow + i * kVec;
+#pragma unroll
+    for (int j = 0; j < kVec; ++j) max_value = fmaxf(max_value, fabsf(static_cast<float>(p[j])));
+  }
+  float warp_max = warpReduceMax(max_value);
+  float scale = warp_max / kFP8E4M3Max;
+  if (lane_id == 0) out_s[token_id] = scale;
+  float scale_inv = (scale == 0.f) ? 0.f : 1.0f / scale;
+
+  for (int i = lane_id; i < num_vec; i += kWarpSize) {
+    const T* p = trow + i * kVec;
+    __nv_fp8_e4m3 tmp[kVec];
+#pragma unroll
+    for (int j = 0; j < kVec; ++j) {
+      float val = static_cast<float>(p[j]) * scale_inv;
+      val = fmaxf(fminf(val, kFP8E4M3Max), -kFP8E4M3Max);
+      tmp[j] = static_cast<__nv_fp8_e4m3>(val);
+    }
+    if constexpr (kVec == 16) {
+      *reinterpret_cast<uint4*>(orow + i * kVec) = *reinterpret_cast<uint4*>(tmp);
+    } else {
+#pragma unroll
+      for (int j = 0; j < kVec; ++j) orow[i * kVec + j] = tmp[j];
+    }
+  }
+}
+
+// One block per token (small batch); block reduce.
+template <typename T, int kVec>
+__global__ void perTokenQuantBlock(
+    const T* __restrict__ input, __nv_fp8_e4m3* __restrict__ out_q, float* __restrict__ out_s,
+    const int64_t hidden_dim, const int64_t num_tokens) {
+  const int token_idx = blockIdx.x;
+  if (token_idx >= num_tokens) return;
+  const int tid = threadIdx.x;
+  const T* trow = input + token_idx * hidden_dim;
+  __nv_fp8_e4m3* orow = out_q + token_idx * hidden_dim;
+  const int num_vec = hidden_dim / kVec;
+
+  float max_value = 0.f;
+  for (int i = tid; i < num_vec; i += blockDim.x) {
+    const T* p = trow + i * kVec;
+#pragma unroll
+    for (int j = 0; j < kVec; ++j) max_value = fmaxf(max_value, fabsf(static_cast<float>(p[j])));
+  }
+  max_value = blockReduceMax(max_value);
+  __shared__ float scale;
+  if (tid == 0) {
+    scale = max_value / kFP8E4M3Max;
+    out_s[token_idx] = scale;
+  }
+  __syncthreads();
+  float scale_inv = (scale == 0.f) ? 0.f : 1.0f / scale;
+
+  for (int i = tid; i < num_vec; i += blockDim.x) {
+    const T* p = trow + i * kVec;
+    __nv_fp8_e4m3 tmp[kVec];
+#pragma unroll
+    for (int j = 0; j < kVec; ++j) {
+      float val = static_cast<float>(p[j]) * scale_inv;
+      val = fmaxf(fminf(val, kFP8E4M3Max), -kFP8E4M3Max);
+      tmp[j] = static_cast<__nv_fp8_e4m3>(val);
+    }
+    if constexpr (kVec == 16) {
+      *reinterpret_cast<uint4*>(orow + i * kVec) = *reinterpret_cast<uint4*>(tmp);
+    } else {
+#pragma unroll
+      for (int j = 0; j < kVec; ++j) orow[i * kVec + j] = tmp[j];
+    }
+  }
+}
+
+template <typename T>
+void dispatch_vec(bool warp, dim3 grid, dim3 block, cudaStream_t stream, const T* in,
+                  __nv_fp8_e4m3* q, float* s, int64_t hd, int64_t nt) {
+  constexpr int TPC = 8;
+  bool v16 = (hd % 16 == 0), v8 = (hd % 8 == 0);
+  if (warp) {
+    if (v16) perTokenQuantWarp<T, TPC, 16><<<grid, block, 0, stream>>>(in, q, s, hd, nt);
+    else if (v8) perTokenQuantWarp<T, TPC, 8><<<grid, block, 0, stream>>>(in, q, s, hd, nt);
+    else perTokenQuantWarp<T, TPC, 4><<<grid, block, 0, stream>>>(in, q, s, hd, nt);
+  } else {
+    if (v16) perTokenQuantBlock<T, 16><<<grid, block, 0, stream>>>(in, q, s, hd, nt);
+    else if (v8) perTokenQuantBlock<T, 8><<<grid, block, 0, stream>>>(in, q, s, hd, nt);
+    else perTokenQuantBlock<T, 4><<<grid, block, 0, stream>>>(in, q, s, hd, nt);
+  }
+}
+
+}  // namespace
+
+void sgl_per_token_quant_fp8(torch::Tensor input, torch::Tensor output_q, torch::Tensor output_s) {
+  JO_CHECK_CUDA(input);
+  JO_CHECK_CONTIGUOUS(input);
+  JO_CHECK_CUDA(output_q);
+  JO_CHECK_CUDA(output_s);
+  TORCH_CHECK(input.dim() == 2, "input must be 2D [num_tokens, hidden_dim]");
+  const int64_t num_tokens = input.size(0);
+  const int64_t hidden_dim = input.size(1);
+  TORCH_CHECK(hidden_dim % 4 == 0, "hidden_dim must be divisible by 4, got ", hidden_dim);
+
+  const c10::cuda::CUDAGuard guard(input.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
+  const int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+  constexpr int TPC = 8;
+  const bool warp = (num_tokens >= sm_count * 2 * TPC);
+  dim3 grid = warp ? dim3((num_tokens + TPC - 1) / TPC) : dim3((unsigned)num_tokens);
+  dim3 block(256);
+
+  auto* q = static_cast<__nv_fp8_e4m3*>(output_q.data_ptr());
+  auto* s = static_cast<float*>(output_s.data_ptr());
+  if (input.scalar_type() == torch::kBFloat16)
+    dispatch_vec<__nv_bfloat16>(warp, grid, block, stream,
+                                static_cast<const __nv_bfloat16*>(input.data_ptr()), q, s, hidden_dim, num_tokens);
+  else if (input.scalar_type() == torch::kFloat16)
+    dispatch_vec<__half>(warp, grid, block, stream,
+                         static_cast<const __half*>(input.data_ptr()), q, s, hidden_dim, num_tokens);
+  else
+    TORCH_CHECK(false, "per_token_quant_fp8: input must be bf16 or fp16");
+}
+
+}  // namespace joyomni_ops

--- a/joyomni_ops/csrc/pybind.cpp
+++ b/joyomni_ops/csrc/pybind.cpp
@@ -1,0 +1,58 @@
+// Single Torch library registration for joyomni_ops.
+// Op names are exposed as torch.ops.joyomni_ops.<name> and mirror the sgl_kernel
+// signatures the JoyOmni pipeline uses, so the Python shim is a thin rename.
+//
+// Define JOYOMNI_OPS_NO_FP8 to build without the cutlass FP8 GEMM (lets the 3
+// light kernels compile on toolchains without cutlass / CUDA<12.8).
+#include <torch/all.h>
+#include <torch/library.h>
+
+namespace joyomni_ops {
+
+void fused_qk_norm_rope_3d_paired(
+    torch::Tensor& q, torch::Tensor& k, int64_t seq_len, int64_t num_heads, double eps,
+    torch::Tensor& q_weight, torch::Tensor& k_weight, torch::Tensor& cos, torch::Tensor& sin);
+
+torch::Tensor fused_norm_scale_shift(
+    const torch::Tensor& x, const c10::optional<torch::Tensor>& gamma_opt,
+    const c10::optional<torch::Tensor>& beta_opt, const torch::Tensor& scale,
+    const torch::Tensor& shift, int64_t norm_type, double eps);
+
+torch::Tensor rmsnorm(const torch::Tensor& x, const torch::Tensor& weight, double eps);
+
+#ifndef JOYOMNI_OPS_NO_FP8
+void sgl_per_token_quant_fp8(torch::Tensor input, torch::Tensor output_q, torch::Tensor output_s);
+
+torch::Tensor fp8_scaled_mm(
+    const torch::Tensor& mat_a, const torch::Tensor& mat_b, const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b, const torch::ScalarType& out_dtype,
+    const c10::optional<torch::Tensor>& bias);
+#endif
+
+}  // namespace joyomni_ops
+
+TORCH_LIBRARY(joyomni_ops, m) {
+  m.def(
+      "fused_qk_norm_rope_3d_paired(Tensor! q, Tensor! k, int seq_len, int num_heads, float eps, "
+      "Tensor q_weight, Tensor k_weight, Tensor cos, Tensor sin) -> ()");
+  m.def(
+      "fused_norm_scale_shift(Tensor x, Tensor? gamma_opt, Tensor? beta_opt, "
+      "Tensor scale, Tensor shift, int norm_type, float eps) -> Tensor");
+  m.def("rmsnorm(Tensor x, Tensor weight, float eps) -> Tensor");
+#ifndef JOYOMNI_OPS_NO_FP8
+  m.def("sgl_per_token_quant_fp8(Tensor input, Tensor! output_q, Tensor! output_s) -> ()");
+  m.def(
+      "fp8_scaled_mm(Tensor mat_a, Tensor mat_b, Tensor scales_a, Tensor scales_b, "
+      "ScalarType out_dtype, Tensor? bias) -> Tensor");
+#endif
+}
+
+TORCH_LIBRARY_IMPL(joyomni_ops, CUDA, m) {
+  m.impl("fused_qk_norm_rope_3d_paired", &joyomni_ops::fused_qk_norm_rope_3d_paired);
+  m.impl("fused_norm_scale_shift", &joyomni_ops::fused_norm_scale_shift);
+  m.impl("rmsnorm", &joyomni_ops::rmsnorm);
+#ifndef JOYOMNI_OPS_NO_FP8
+  m.impl("sgl_per_token_quant_fp8", &joyomni_ops::sgl_per_token_quant_fp8);
+  m.impl("fp8_scaled_mm", &joyomni_ops::fp8_scaled_mm);
+#endif
+}

--- a/joyomni_ops/csrc/rmsnorm.cu
+++ b/joyomni_ops/csrc/rmsnorm.cu
@@ -1,0 +1,97 @@
+/*
+ * Standalone RMSNorm:  out[i] = (x[i] * rsqrt(mean(x^2) + eps)) * weight[i]
+ * Self-written (no flashinfer). One block per row, warp/block reduction.
+ * Supports bf16 / fp16 / fp32. x: [M, N] row-contiguous; weight: [N].
+ */
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include <algorithm>
+
+#include "joyomni_ops.h"
+
+namespace joyomni_ops {
+namespace {
+
+__device__ __forceinline__ float warpSum(float v) {
+#pragma unroll
+  for (int o = 16; o > 0; o >>= 1) v += __shfl_down_sync(0xffffffffu, v, o);
+  return v;
+}
+
+__device__ __forceinline__ float blockSum(float v) {
+  __shared__ float sh[32];
+  int lane = threadIdx.x & 31, wid = threadIdx.x >> 5;
+  v = warpSum(v);
+  if (lane == 0) sh[wid] = v;
+  __syncthreads();
+  int nwarps = (blockDim.x + 31) / 32;
+  v = (threadIdx.x < nwarps) ? sh[lane] : 0.0f;
+  if (wid == 0) v = warpSum(v);
+  return v;  // valid on thread 0
+}
+
+template <typename T>
+__global__ void rmsnormKernel(
+    T* __restrict__ out, const T* __restrict__ x, const T* __restrict__ weight,
+    const int n, const float eps) {
+  const int row = blockIdx.x;
+  const int tid = threadIdx.x;
+  x += (size_t)row * n;
+  out += (size_t)row * n;
+
+  float local = 0.0f;
+  for (int i = tid; i < n; i += blockDim.x) {
+    float v = static_cast<float>(x[i]);
+    local += v * v;
+  }
+  local = blockSum(local);
+  __shared__ float s_rms;
+  if (tid == 0) s_rms = rsqrtf(local / n + eps);
+  __syncthreads();
+  const float rms = s_rms;
+
+  for (int i = tid; i < n; i += blockDim.x) {
+    float v = static_cast<float>(x[i]) * rms * static_cast<float>(weight[i]);
+    out[i] = T(v);
+  }
+}
+
+template <typename T>
+void launch(const torch::Tensor& x, const torch::Tensor& weight, torch::Tensor& out, float eps) {
+  const int64_t M = x.size(0), N = x.size(1);
+  int block = (int)std::min<int64_t>(1024, ((N + 31) / 32) * 32);
+  if (block < 32) block = 32;
+  dim3 grid((unsigned)M);
+  auto stream = at::cuda::getCurrentCUDAStream();
+  rmsnormKernel<T><<<grid, block, 0, stream>>>(
+      (T*)out.data_ptr(), (const T*)x.data_ptr(), (const T*)weight.data_ptr(), (int)N, eps);
+}
+
+}  // namespace
+
+torch::Tensor rmsnorm(const torch::Tensor& x, const torch::Tensor& weight, double eps) {
+  JO_CHECK_CUDA(x);
+  JO_CHECK_CUDA(weight);
+  TORCH_CHECK(x.dim() == 2, "x must be 2D [M, N]");
+  TORCH_CHECK(x.stride(-1) == 1, "x last dim must be contiguous");
+  TORCH_CHECK(weight.dim() == 1 && weight.numel() == x.size(1), "weight must be 1D [N]");
+  TORCH_CHECK(x.dtype() == weight.dtype(), "x and weight dtype must match");
+
+  const c10::cuda::CUDAGuard guard(x.device());
+  auto out = torch::empty_like(x);
+  if (x.dtype() == torch::kFloat32)
+    launch<float>(x, weight, out, (float)eps);
+  else if (x.dtype() == torch::kFloat16)
+    launch<__half>(x, weight, out, (float)eps);
+  else if (x.dtype() == torch::kBFloat16)
+    launch<__nv_bfloat16>(x, weight, out, (float)eps);
+  else
+    TORCH_CHECK(false, "Unsupported dtype; use float32/float16/bfloat16");
+  return out;
+}
+
+}  // namespace joyomni_ops

--- a/joyomni_ops/include/joyomni_ops.h
+++ b/joyomni_ops/include/joyomni_ops.h
@@ -1,0 +1,25 @@
+// Minimal shared utilities for joyomni_ops kernels.
+// Self-contained: depends only on PyTorch + CUDA. No sgl-kernel / flashinfer.
+#pragma once
+
+#include <cuda_runtime.h>
+#include <torch/all.h>
+
+#define JO_CHECK_CUDA(x) TORCH_CHECK((x).is_cuda(), #x " must be a CUDA tensor")
+#define JO_CHECK_CONTIGUOUS(x) TORCH_CHECK((x).is_contiguous(), #x " must be contiguous")
+#define JO_CHECK_DTYPE(x, dt) \
+  TORCH_CHECK((x).scalar_type() == (dt), #x " dtype is ", (x).scalar_type(), ", expected ", (dt))
+#define JO_CHECK_INPUT(x, dt) \
+  JO_CHECK_CUDA(x);           \
+  JO_CHECK_CONTIGUOUS(x);     \
+  JO_CHECK_DTYPE(x, dt)
+
+// Compute capability (major*10 + minor) of the current CUDA device.
+inline int getSMVersion() {
+  int device{-1};
+  cudaGetDevice(&device);
+  int major = 0, minor = 0;
+  cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device);
+  cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device);
+  return major * 10 + minor;
+}

--- a/joyomni_ops/include/math.hpp
+++ b/joyomni_ops/include/math.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <climits>
+#include <iostream>
+
+inline constexpr uint32_t next_pow_2(uint32_t const num) {
+  if (num <= 1) return num;
+  return 1 << (CHAR_BIT * sizeof(num) - __builtin_clz(num - 1));
+}
+
+template <typename A, typename B>
+static inline constexpr auto div_ceil(A a, B b) {
+  return (a + b - 1) / b;
+}
+
+// Round a down to the next multiple of b. The caller is responsible for making
+// sure that b is non-zero
+template <typename T>
+inline constexpr T round_to_previous_multiple_of(T a, T b) {
+  return a % b == 0 ? a : (a / b) * b;
+}
+
+// Round a up to the next multiple of b. The caller is responsible for making
+// sure that b is non-zero
+template <typename T>
+inline constexpr T round_to_next_multiple_of(T a, T b) {
+  return a % b == 0 ? a : ((a / b) + 1) * b;
+}

--- a/joyomni_ops/joyomni_ops/__init__.py
+++ b/joyomni_ops/joyomni_ops/__init__.py
@@ -1,0 +1,58 @@
+"""joyomni_ops — minimal self-contained CUDA ops for the JoyOmni V2V DiT pipeline.
+
+Extracted from sgl-kernel; no sglang / sgl_kernel runtime dependency.
+Exposes the ops the pipeline uses under a thin wrapper matching the original
+sgl_kernel signatures, so call sites only change the import.
+"""
+import glob
+import os
+from typing import Optional
+
+import torch
+
+# The extension is a pure TORCH_LIBRARY (no pybind module init), so load the .so
+# with torch.ops.load_library to trigger op registration.
+_here = os.path.dirname(__file__)
+_so = glob.glob(os.path.join(_here, "_C*.so"))
+if not _so:
+    raise ImportError(f"joyomni_ops C extension not found in {_here}; build it first (pip install .)")
+torch.ops.load_library(_so[0])
+
+__all__ = [
+    "fused_qk_norm_rope_3d_paired",
+    "fused_norm_scale_shift",
+    "rmsnorm",
+    "sgl_per_token_quant_fp8",
+    "fp8_scaled_mm",
+    "has_fp8",
+]
+
+_ops = torch.ops.joyomni_ops
+
+
+def fused_qk_norm_rope_3d_paired(q, k, seq_len, num_heads, eps, q_weight, k_weight, cos, sin):
+    """In-place fused RMSNorm(q,k) + 3D RoPE. q/k: [B, seq_len*num_heads, head_dim] bf16."""
+    _ops.fused_qk_norm_rope_3d_paired(q, k, seq_len, num_heads, eps, q_weight, k_weight, cos, sin)
+
+
+def fused_norm_scale_shift(x, gamma, beta, scale, shift, norm_type, eps=1e-5):
+    """Norm(x; gamma, beta) * (1 + scale) + shift. norm_type: 'layer' or 'rms'."""
+    nt = 0 if norm_type == "layer" else 1 if norm_type == "rms" else -1
+    return _ops.fused_norm_scale_shift(x, gamma, beta, scale, shift, nt, eps)
+
+
+def rmsnorm(x, weight, eps=1e-6):
+    """(x / RMS(x)) * weight. x: [M, N], weight: [N]."""
+    return _ops.rmsnorm(x, weight, eps)
+
+
+def has_fp8() -> bool:
+    return hasattr(_ops, "fp8_scaled_mm")
+
+
+def sgl_per_token_quant_fp8(input, output_q, output_s):
+    _ops.sgl_per_token_quant_fp8(input, output_q, output_s)
+
+
+def fp8_scaled_mm(mat_a, mat_b, scales_a, scales_b, out_dtype, bias: Optional[torch.Tensor] = None):
+    return _ops.fp8_scaled_mm(mat_a, mat_b, scales_a, scales_b, out_dtype, bias)

--- a/joyomni_ops/setup.py
+++ b/joyomni_ops/setup.py
@@ -1,0 +1,139 @@
+"""Build script for joyomni_ops — a minimal, self-contained CUDA operator library
+extracted from sgl-kernel for the JoyOmni V2V DiT pipeline.
+
+Ops provided (no sgl-kernel / sglang dependency):
+  - fused_qk_norm_rope_3d_paired : fused RMSNorm(q,k) + 3D RoPE   (bf16)
+  - fused_norm_scale_shift       : fused LayerNorm/RMSNorm + adaLN modulate
+  - rmsnorm                      : standalone RMSNorm
+  - sgl_per_token_quant_fp8      : dynamic per-token bf16 -> fp8_e4m3 quant
+  - fp8_scaled_mm                : FP8 per-token x per-channel scaled GEMM (cutlass)
+
+GPU arch coverage is chosen from the local nvcc version:
+  - always: sm_80, sm_89, sm_90
+  - CUDA >= 12.8: also sm_100a (B200) and sm_120a (RTX 5090)
+So building on a CUDA 12.8+ toolchain automatically yields Blackwell support.
+"""
+import os
+from pathlib import Path
+
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+THIS_DIR = Path(__file__).parent.resolve()
+
+
+def _cuda_version():
+    """(major, minor) of the nvcc that torch will use, or (0, 0) if unknown."""
+    from torch.utils.cpp_extension import CUDA_HOME
+    import subprocess
+    try:
+        nvcc = os.path.join(CUDA_HOME or "/usr/local/cuda", "bin", "nvcc")
+        out = subprocess.check_output([nvcc, "--version"], text=True)
+        for line in out.splitlines():
+            if "release" in line:
+                tok = line.split("release")[1].strip().split(",")[0]  # "12.6"
+                mj, mn = tok.split(".")[:2]
+                return int(mj), int(mn)
+    except Exception:
+        pass
+    return (0, 0)
+
+
+def _gencodes():
+    """-gencode flags. Blackwell (sm_100a/sm_120a) needs nvcc >= 12.8."""
+    mj, mn = _cuda_version()
+    # Allow override, e.g. JOYOMNI_OPS_CUDA_ARCHS="90;120a"
+    override = os.environ.get("JOYOMNI_OPS_CUDA_ARCHS")
+    if override:
+        flags = []
+        for a in override.split(";"):
+            a = a.strip()
+            if not a:
+                continue
+            code = f"sm_{a}"
+            arch = f"compute_{a}"
+            flags += [f"-gencode=arch={arch},code={code}"]
+        return flags
+    flags = [
+        "-gencode=arch=compute_80,code=sm_80",
+        "-gencode=arch=compute_89,code=sm_89",
+        "-gencode=arch=compute_90,code=sm_90",
+    ]
+    if (mj, mn) >= (12, 8):
+        flags += [
+            "-gencode=arch=compute_100a,code=sm_100a",
+            "-gencode=arch=compute_120a,code=sm_120a",
+            # PTX fallback so newer archs (e.g. sm_121) can JIT.
+            "-gencode=arch=compute_120,code=compute_120",
+        ]
+    else:
+        # No SASS for sm_100/sm_120 on this toolchain; embed sm_90 PTX so the
+        # driver can JIT for Blackwell (sm_100/sm_120) at load time. Correctness
+        # only — for tuned Blackwell SASS, build on CUDA >= 12.8.
+        flags += ["-gencode=arch=compute_90,code=compute_90"]
+        print(
+            f"[joyomni_ops] nvcc {mj}.{mn} < 12.8: SASS sm_80/89/90 + sm_90 PTX "
+            f"(JIT fallback for Blackwell). Build on CUDA >= 12.8 for native sm_100a/sm_120a."
+        )
+    return flags
+
+
+SOURCES = [
+    "csrc/pybind.cpp",
+    "csrc/fused_qknorm_rope_3d_kernel.cu",
+    "csrc/fused_norm_scale_shift.cu",
+    "csrc/rmsnorm.cu",
+]
+
+# FP8 GEMM needs cutlass (and CUDA >= 12.8 for Blackwell). Set JOYOMNI_OPS_NO_FP8=1
+# to build only the 3 light kernels (no cutlass required).
+NO_FP8 = os.environ.get("JOYOMNI_OPS_NO_FP8", "").lower() in {"1", "true", "yes", "on"}
+if not NO_FP8:
+    SOURCES += ["csrc/per_token_quant_fp8.cu", "csrc/fp8_gemm.cu"]
+
+nvcc_flags = [
+    "-O3",
+    "-std=c++17",
+    "--expt-relaxed-constexpr",
+    "--expt-extended-lambda",
+    "-U__CUDA_NO_HALF_OPERATORS__",
+    "-U__CUDA_NO_HALF_CONVERSIONS__",
+    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+] + _gencodes()
+
+cxx_flags = ["-O3", "-std=c++17"]
+if NO_FP8:
+    nvcc_flags.append("-DJOYOMNI_OPS_NO_FP8")
+    cxx_flags.append("-DJOYOMNI_OPS_NO_FP8")
+
+include_dirs = [str(THIS_DIR / "include")]
+
+# cutlass (for fp8_scaled_mm). Point JOYOMNI_OPS_CUTLASS_DIR at a cutlass checkout
+# (tag 57e3cfb47a2d9e0d46eb6335c3dc411498efa198 matches the reference build).
+cutlass_dir = os.environ.get("JOYOMNI_OPS_CUTLASS_DIR")
+if not NO_FP8:
+    if cutlass_dir:
+        include_dirs += [
+            os.path.join(cutlass_dir, "include"),
+            os.path.join(cutlass_dir, "tools", "util", "include"),
+        ]
+    else:
+        print("[joyomni_ops] JOYOMNI_OPS_CUTLASS_DIR not set — fp8_gemm.cu will fail to "
+              "compile. Set it, or build with JOYOMNI_OPS_NO_FP8=1.")
+
+setup(
+    name="joyomni_ops",
+    version="0.1.0",
+    description="Minimal self-contained CUDA ops for the JoyOmni V2V DiT pipeline",
+    packages=["joyomni_ops"],
+    ext_modules=[
+        CUDAExtension(
+            name="joyomni_ops._C",
+            sources=SOURCES,
+            include_dirs=include_dirs,
+            extra_compile_args={"cxx": cxx_flags, "nvcc": nvcc_flags},
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension},
+    python_requires=">=3.9",
+)

--- a/joyomni_ops/tests/test_bench.py
+++ b/joyomni_ops/tests/test_bench.py
@@ -1,0 +1,223 @@
+"""Benchmark + accuracy test for joyomni_ops vs pure-PyTorch reference.
+
+For each op:
+  - correctness: max abs / mean rel error vs a pure-torch (fp32-accumulate) impl,
+    and vs sgl_kernel when available (should be ~0).
+  - speed: CUDA-event timed, joyomni_ops kernel vs the equivalent eager torch
+    ops, reporting the speedup.
+
+Usage:
+  python tests/test_bench.py
+  python tests/test_bench.py --dtype fp16 --iters 200
+"""
+import argparse
+
+import torch
+
+import joyomni_ops as jo
+
+try:
+    import sgl_kernel as sk
+    HAVE_SGL = True
+except Exception:
+    HAVE_SGL = False
+
+DEV = "cuda"
+
+
+def bench(fn, warmup=25, iters=100):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters  # ms
+
+
+def errs(a, b):
+    a = a.float()
+    b = b.float()
+    max_abs = (a - b).abs().max().item()
+    rel = ((a - b).abs().mean() / b.abs().mean().clamp_min(1e-9)).item()
+    return max_abs, rel
+
+
+def line(name, max_abs, rel, t_ker, t_ref):
+    sp = t_ref / t_ker if t_ker > 0 else float("inf")
+    print(f"{name:26s} | max_abs={max_abs:9.3e} rel={rel:8.2e} | "
+          f"kernel={t_ker*1000:7.1f}us torch={t_ref*1000:7.1f}us speedup={sp:5.2f}x")
+
+
+# ---------------------------------------------------------------------------
+# rmsnorm
+# ---------------------------------------------------------------------------
+def run_rmsnorm(dt, iters):
+    M, N = 4096, 4096
+    x = torch.randn(M, N, device=DEV, dtype=dt)
+    w = torch.randn(N, device=DEV, dtype=dt)
+    eps = 1e-6
+
+    def torch_ref():
+        xf = x.float()
+        return ((xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + eps)) * w.float()).to(dt)
+
+    out = jo.rmsnorm(x, w, eps)
+    max_abs, rel = errs(out, torch_ref())
+    t_ker = bench(lambda: jo.rmsnorm(x, w, eps), iters=iters)
+    t_ref = bench(torch_ref, iters=iters)
+    line("rmsnorm", max_abs, rel, t_ker, t_ref)
+    if HAVE_SGL:
+        s = errs(out, sk.rmsnorm(x, w, eps))
+        print(f"{'  └ vs sgl_kernel':26s} | max_abs={s[0]:9.3e}")
+
+
+# ---------------------------------------------------------------------------
+# fused_norm_scale_shift (LayerNorm + adaLN)
+# ---------------------------------------------------------------------------
+def run_norm_scale_shift(dt, iters):
+    M, N = 4096, 4096
+    x = torch.randn(M, N, device=DEV, dtype=dt)
+    gamma = torch.randn(N, device=DEV, dtype=dt)
+    beta = torch.randn(N, device=DEV, dtype=dt)
+    scale = torch.randn(M, N, device=DEV, dtype=dt)
+    shift = torch.randn(M, N, device=DEV, dtype=dt)
+    eps = 1e-5
+
+    def torch_ref():
+        xf = x.float()
+        mean = xf.mean(-1, keepdim=True)
+        var = (xf - mean).pow(2).mean(-1, keepdim=True)
+        ln = (xf - mean) * torch.rsqrt(var + eps) * gamma.float() + beta.float()
+        return (ln * (1 + scale.float()) + shift.float()).to(dt)
+
+    out = jo.fused_norm_scale_shift(x, gamma, beta, scale, shift, "layer", eps)
+    max_abs, rel = errs(out, torch_ref())
+    t_ker = bench(lambda: jo.fused_norm_scale_shift(x, gamma, beta, scale, shift, "layer", eps), iters=iters)
+    t_ref = bench(torch_ref, iters=iters)
+    line("fused_norm_scale_shift", max_abs, rel, t_ker, t_ref)
+    if HAVE_SGL:
+        s = errs(out, sk.fused_norm_scale_shift(x, gamma, beta, scale, shift, "layer", eps))
+        print(f"{'  └ vs sgl_kernel':26s} | max_abs={s[0]:9.3e}")
+
+
+# ---------------------------------------------------------------------------
+# fused_qk_norm_rope_3d_paired (bf16 only — the kernel is bf16)
+# ---------------------------------------------------------------------------
+def run_qk_norm_rope(iters):
+    dt = torch.bfloat16
+    B, seq_len, num_heads, head_dim = 1, 1560, 32, 128  # steady-state DiT shape
+    M = seq_len * num_heads
+    q0 = torch.randn(B, M, head_dim, device=DEV, dtype=dt)
+    k0 = torch.randn(B, M, head_dim, device=DEV, dtype=dt)
+    qw = torch.randn(head_dim, device=DEV, dtype=dt)
+    kw = torch.randn(head_dim, device=DEV, dtype=dt)
+    cos = torch.randn(seq_len, head_dim // 2, device=DEV, dtype=dt)
+    sin = torch.randn(seq_len, head_dim // 2, device=DEV, dtype=dt)
+    eps = 1e-6
+
+    def torch_ref_one(x, w):
+        xf = x.float().view(B, seq_len, num_heads, head_dim)
+        xn = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + eps) * w.float()
+        c = cos.float().view(seq_len, 1, head_dim // 2)
+        s = sin.float().view(seq_len, 1, head_dim // 2)
+        x1, x2 = xn[..., 0::2], xn[..., 1::2]
+        o = torch.empty_like(xn)
+        o[..., 0::2] = x1 * c - x2 * s
+        o[..., 1::2] = x1 * s + x2 * c
+        return o.view(B, M, head_dim).to(dt)
+
+    # kernel is in-place; work on clones
+    qj, kj = q0.clone(), k0.clone()
+    jo.fused_qk_norm_rope_3d_paired(qj, kj, seq_len, num_heads, eps, qw, kw, cos, sin)
+    max_abs, rel = errs(qj, torch_ref_one(q0, qw))
+
+    def ker():
+        q, k = q0.clone(), k0.clone()
+        jo.fused_qk_norm_rope_3d_paired(q, k, seq_len, num_heads, eps, qw, kw, cos, sin)
+
+    def ref():
+        torch_ref_one(q0, qw)
+        torch_ref_one(k0, kw)
+
+    t_ker = bench(ker, iters=iters)
+    t_ref = bench(ref, iters=iters)
+    line("qk_norm_rope_3d_paired", max_abs, rel, t_ker, t_ref)
+    if HAVE_SGL:
+        qs, ks = q0.clone(), k0.clone()
+        sk.fused_qk_norm_rope_3d_paired(qs, ks, seq_len, num_heads, eps, qw, kw, cos, sin)
+        s = errs(qj, qs)
+        print(f"{'  └ vs sgl_kernel':26s} | max_abs={s[0]:9.3e}")
+
+
+# ---------------------------------------------------------------------------
+# fp8 linear: quant + fp8_scaled_mm  vs  bf16/fp16 torch matmul
+# ---------------------------------------------------------------------------
+def run_fp8_linear(dt, iters):
+    if not jo.has_fp8():
+        print("fp8_scaled_mm            | (not built — JOYOMNI_OPS_NO_FP8)")
+        return
+    M, K, N = 4096, 4096, 4096
+    x = torch.randn(M, K, device=DEV, dtype=dt)
+    w = torch.randn(N, K, device=DEV, dtype=dt)  # weight [N, K] row-major
+
+    # Pre-quant the weight once (as an Fp8Linear would at load time).
+    wq = torch.empty(N, K, device=DEV, dtype=torch.float8_e4m3fn)
+    wsc = torch.empty(N, device=DEV, dtype=torch.float32)
+    jo.sgl_per_token_quant_fp8(w, wq, wsc)
+    wq_t = wq.t()  # [K, N] col-major
+
+    xq = torch.empty(M, K, device=DEV, dtype=torch.float8_e4m3fn)
+    xsc = torch.empty(M, device=DEV, dtype=torch.float32)
+
+    def fp8_path():
+        jo.sgl_per_token_quant_fp8(x, xq, xsc)  # dynamic per-token quant of activation
+        return jo.fp8_scaled_mm(xq, wq_t, xsc, wsc, dt, None)
+
+    def torch_path():
+        return torch.matmul(x, w.t())  # eager bf16/fp16 GEMM
+
+    out = fp8_path()
+    ref = torch_path()
+    max_abs, rel = errs(out, ref)
+    t_ker = bench(fp8_path, iters=iters)
+    t_ref = bench(torch_path, iters=iters)
+    line(f"fp8 linear (quant+mm)", max_abs, rel, t_ker, t_ref)
+    # mm only (weight already quantized, activation pre-quantized) — the steady cost
+    jo.sgl_per_token_quant_fp8(x, xq, xsc)
+
+    def mm_only():
+        return jo.fp8_scaled_mm(xq, wq_t, xsc, wsc, dt, None)
+
+    t_mm = bench(mm_only, iters=iters)
+    line(f"fp8 mm only", *errs(mm_only(), ref), t_mm, t_ref)
+    if HAVE_SGL:
+        s = errs(mm_only(), sk.fp8_scaled_mm(xq, wq_t, xsc, wsc, dt, None))
+        print(f"{'  └ vs sgl_kernel':26s} | max_abs={s[0]:9.3e}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dtype", default="bf16", choices=["bf16", "fp16"])
+    ap.add_argument("--iters", type=int, default=100)
+    args = ap.parse_args()
+    dt = torch.bfloat16 if args.dtype == "bf16" else torch.float16
+
+    print(f"device={torch.cuda.get_device_name(0)}  dtype={args.dtype}  "
+          f"iters={args.iters}  sgl_kernel={'yes' if HAVE_SGL else 'no'}  has_fp8={jo.has_fp8()}")
+    print("-" * 100)
+    run_rmsnorm(dt, args.iters)
+    run_norm_scale_shift(dt, args.iters)
+    run_qk_norm_rope(args.iters)  # bf16 only
+    run_fp8_linear(dt, args.iters)
+    print("-" * 100)
+    print("Notes: fp8 rel-err vs torch is the inherent fp8 quantization error (~few %),")
+    print("       not a bug. Correctness vs sgl_kernel should be ~0.")
+
+
+if __name__ == "__main__":
+    main()

--- a/joyomni_ops/tests/test_parity_light.py
+++ b/joyomni_ops/tests/test_parity_light.py
@@ -1,0 +1,96 @@
+"""Numerical parity: joyomni_ops vs sgl_kernel for the 3 light ops.
+Run on a CUDA GPU with both packages importable:
+  python tests/test_parity_light.py
+"""
+import torch
+import joyomni_ops as jo
+
+try:
+    import sgl_kernel as sk
+    HAVE_SGL = True
+except Exception as e:  # noqa: BLE001
+    HAVE_SGL = False
+    print(f"[warn] sgl_kernel not importable ({e!r}); running self-consistency only")
+
+dev = "cuda"
+torch.manual_seed(0)
+
+
+def report(name, a, b):
+    d = (a.float() - b.float()).abs().max().item()
+    print(f"{name:34s} max_diff={d:.3e}  {'OK' if d < 1e-2 else 'FAIL'}")
+    return d
+
+
+def test_rmsnorm():
+    M, N = 512, 4096
+    x = torch.randn(M, N, device=dev, dtype=torch.bfloat16)
+    w = torch.randn(N, device=dev, dtype=torch.bfloat16)
+    out = jo.rmsnorm(x, w, 1e-6)
+    # reference in fp32
+    xf = x.float()
+    ref = (xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + 1e-6)) * w.float()
+    report("rmsnorm vs fp32-ref", out, ref)
+    if HAVE_SGL:
+        report("rmsnorm vs sgl", out, sk.rmsnorm(x, w, 1e-6))
+
+
+def test_fused_norm_scale_shift():
+    M, N = 512, 4096
+    x = torch.randn(M, N, device=dev, dtype=torch.bfloat16)
+    gamma = torch.randn(N, device=dev, dtype=torch.bfloat16)
+    beta = torch.randn(N, device=dev, dtype=torch.bfloat16)
+    scale = torch.randn(M, N, device=dev, dtype=torch.bfloat16)
+    shift = torch.randn(M, N, device=dev, dtype=torch.bfloat16)
+    out = jo.fused_norm_scale_shift(x, gamma, beta, scale, shift, "layer", 1e-5)
+    # fp32 ref: LayerNorm then modulate
+    xf = x.float()
+    mean = xf.mean(-1, keepdim=True)
+    var = (xf - mean).pow(2).mean(-1, keepdim=True)
+    ln = (xf - mean) * torch.rsqrt(var + 1e-5) * gamma.float() + beta.float()
+    ref = ln * (1 + scale.float()) + shift.float()
+    report("norm_scale_shift vs fp32-ref", out, ref)
+    if HAVE_SGL:
+        report("norm_scale_shift vs sgl", out, sk.fused_norm_scale_shift(x, gamma, beta, scale, shift, "layer", 1e-5))
+
+
+def test_qk_norm_rope():
+    B, seq_len, num_heads, head_dim = 1, 128, 8, 128
+    M = seq_len * num_heads
+    q = torch.randn(B, M, head_dim, device=dev, dtype=torch.bfloat16)
+    k = torch.randn(B, M, head_dim, device=dev, dtype=torch.bfloat16)
+    qw = torch.randn(head_dim, device=dev, dtype=torch.bfloat16)
+    kw = torch.randn(head_dim, device=dev, dtype=torch.bfloat16)
+    cos = torch.randn(seq_len, head_dim // 2, device=dev, dtype=torch.bfloat16)
+    sin = torch.randn(seq_len, head_dim // 2, device=dev, dtype=torch.bfloat16)
+    if HAVE_SGL:
+        q_j, k_j = q.clone(), k.clone()
+        q_s, k_s = q.clone(), k.clone()
+        jo.fused_qk_norm_rope_3d_paired(q_j, k_j, seq_len, num_heads, 1e-6, qw, kw, cos, sin)
+        sk.fused_qk_norm_rope_3d_paired(q_s, k_s, seq_len, num_heads, 1e-6, qw, kw, cos, sin)
+        report("qk_norm_rope q vs sgl", q_j, q_s)
+        report("qk_norm_rope k vs sgl", k_j, k_s)
+    else:
+        q_j, k_j = q.clone(), k.clone()
+        jo.fused_qk_norm_rope_3d_paired(q_j, k_j, seq_len, num_heads, 1e-6, qw, kw, cos, sin)
+        # fp32 ref
+        def ref_one(x, w):
+            xf = x.float().view(B, seq_len, num_heads, head_dim)
+            xn = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + 1e-6) * w.float()
+            c = cos.float().view(seq_len, 1, head_dim // 2)
+            s = sin.float().view(seq_len, 1, head_dim // 2)
+            x1 = xn[..., 0::2]
+            x2 = xn[..., 1::2]
+            o = torch.empty_like(xn)
+            o[..., 0::2] = x1 * c - x2 * s
+            o[..., 1::2] = x1 * s + x2 * c
+            return o.view(B, M, head_dim)
+        report("qk_norm_rope q vs fp32-ref", q_j, ref_one(q, qw))
+        report("qk_norm_rope k vs fp32-ref", k_j, ref_one(k, kw))
+
+
+if __name__ == "__main__":
+    print("has_fp8:", jo.has_fp8())
+    test_rmsnorm()
+    test_fused_norm_scale_shift()
+    test_qk_norm_rope()

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,11 @@ loguru==0.7.3
 
 triton==3.5.1
 flash-attn-4==4.0.0b13
-sgl-kernel==0.3.18.post2
+# Fused DiT CUDA ops (RMSNorm / adaLN modulate / 3D-RoPE QK-norm / FP8) are
+# provided by the vendored `joyomni_ops` package instead of sgl-kernel — the
+# published sgl-kernel wheels do not export the fused ops this pipeline needs.
+# Build it after installing this file: `pip install ./joyomni_ops`
+# (needs a cutlass checkout for the FP8 GEMM; see joyomni_ops/README.md).
 nvidia-cutlass-dsl==4.5.1
 nvidia-cutlass-dsl-libs-base==4.5.1
 cuda-python==13.3.1


### PR DESCRIPTION
Fixes issue #4 (problem 1): the published sgl-kernel wheels (0.3.18.post2 and later) do not export fused_norm_scale_shift or fused_qk_norm_rope_3d_paired, so `from sgl_kernel import ...` in sgl_fused_ops.py raised ImportError at pipeline warmup even though `pip install -r requirements.txt` succeeded. The model was built against an internal sgl-kernel fork.

Replace the runtime sgl-kernel dependency with joyomni_ops, a minimal self-contained CUDA op library (Apache-2.0, provenance headers retained) providing exactly the 5 ops the pipeline uses, with signatures matching sgl_kernel so call sites only change the import:

- vendor joyomni_ops/ (csrc, include, setup.py, __init__.py, tests, README); binaries and build/ excluded, built from source via `pip install ./joyomni_ops`
- requirements.txt: remove `sgl-kernel==0.3.18.post2`, document the build step
- sgl_fused_ops.py: import joyomni_ops; wrap the import in try/except so the existing "not available" guard actually fires (it was dead code before, as the naked import propagated ImportError past it)
- fp8_linear.py: import joyomni_ops; gate availability on has_fp8() so a light (no-FP8) build is handled correctly
- DEPLOYMENT.md: build step, updated import check and kernel-packages table

Does not touch the separate flash-attn-4 / cutlass-dsl pin issue also reported in #4.