### PR TITLE
docs: add a reference note for causal VAE implementation

### DIFF
--- a/deploy/xvideo/models/vae/vae.py
+++ b/deploy/xvideo/models/vae/vae.py
@@ -526,7 +526,10 @@ class Head(nn.Module):
 
 
 class XVAEChunkCausal(ModelMixin, ConfigMixin):
-
+    """For more technical details on high-resolution causal VAE decoding, see:
+    https://github.com/xin1u/UltraFlash
+    """
+    
     @register_to_config
     def __init__(
         self,


### PR DESCRIPTION
Add a reference for further technical details related to the
high-resolution causal VAE implementation.

This is a documentation-only change and does not affect runtime behavior.